### PR TITLE
MELQ-127: Написать тесты для post и основных сущностей, которые сейчас есть

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -34,6 +34,7 @@ end
 # Test tools
 group :development, :test do
   gem 'factory_bot_rails'
+  gem 'fakefs', require: 'fakefs/safe'
   gem 'rspec-rails', '~> 4.0.0'
 end
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
+    fakefs (0.20.1)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
@@ -329,6 +330,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   config
   factory_bot_rails
+  fakefs
   git
   google-cloud-storage
   image_processing (~> 1.2)

--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -3,7 +3,7 @@ module Api
     class PostsController < BaseController
       def image
         send_file(
-          "#{Rails.root}/storage/posts/#{params[:slug]}/#{params[:filename]}",
+          "#{Rails.root}/#{Settings.postsDir}/#{params[:slug]}/#{params[:filename]}",
           disposition: 'inline'
         )
       end

--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -43,13 +43,11 @@ class Post
     end
   end
 
-  def self.find_by(*args)
-    params = args.empty? ? {} : args[0]
-
-    raise ArgumentError 'Args empty' if params.keys.empty?
+  def self.find_by(params = {}, *_args)
+    raise ArgumentError, 'Args empty' if params.keys.empty?
 
     primary_key = params.keys.first
-    raise StandardError 'Not Implemented' if params.keys.length > 1 || primary_key != :slug
+    raise StandardError, 'Not Implemented' if params.keys.length > 1 || primary_key != :slug
 
     Post.get_by_slug(params[:slug])
   end
@@ -72,9 +70,8 @@ class Post
     end
   end
 
-  def images_attachments_attributes=(*args)
-    params = args.empty? ? [] : args[0]
-    raise StandardError 'Args empty' if params.empty?
+  def images_attachments_attributes=(params = [], *_args)
+    raise ArgumentError, 'Args empty' if params.empty?
 
     list = images_list
     dir = "#{Post.posts_dir}/#{slug}"
@@ -103,17 +100,15 @@ class Post
     true
   end
 
-  def assign_attributes(*args)
-    params = args.empty? ? {} : args[0]
-
-    raise StandardError 'Args empty' if params.keys.empty?
+  def assign_attributes(params = {}, *_args)
+    raise ArgumentError, 'Args empty' if params.keys.empty?
 
     self.slug = params['slug'] unless slug
     if params.include?('images_attachments_attributes')
       self.images_attachments_attributes = params['images_attachments_attributes']
     end
     params.each do |k, v|
-      next if k == 'images_attachments_attributes'
+      next if %w[images_attachments_attributes slug].include? k
 
       send("#{k}=", v)
     end
@@ -121,9 +116,8 @@ class Post
     self
   end
 
-  def images=(*args)
-    params = args.empty? ? [] : args[0]
-    raise StandardError 'Args empty' if params.empty?
+  def images=(params = [], *_args)
+    raise ArgumentError, 'Args empty' if params.empty?
 
     dir = "#{Settings.postsDir}/#{slug}"
     FileUtils.mkdir_p dir unless Dir.exist?(dir)
@@ -141,9 +135,8 @@ class Post
     # We don't use accepts_nested_attributes_for for tags, so this method is unused
   end
 
-  def tags_attributes=(*args)
-    params = args.empty? ? [] : args[0]
-    raise StandardError 'Args empty' if params.empty?
+  def tags_attributes=(params = [], *_args)
+    raise ArgumentError, 'Args empty' if params.empty?
 
     params.each do |tag|
       if tag.include?('id')
@@ -222,7 +215,6 @@ class Post
 
   def self.slugs
     dir = posts_dir
-    puts dir
     Dir.open(dir).select do |o|
       !%w[. .. .git].include?(o) and File.directory?("#{dir}/#{o}")
     end
@@ -230,6 +222,8 @@ class Post
 
   def self.get_by_slug(slug)
     dir = "#{Settings.postsDir}/#{slug}"
+    return nil unless Dir.exist?(dir)
+
     manifest = File.open("#{dir}/manifest.json", 'r') do |f|
       JSON.parse(f.read)
     end

--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -15,8 +15,7 @@ class Post
     :updated_at
   )
 
-  def initialize(*args)
-    post = args.compact.empty? ? {} : args[0]
+  def initialize(post = {}, *_args)
     @title = post[:title]
     @content = post[:content]
     @published = post.fetch(:published, false)
@@ -223,10 +222,9 @@ class Post
 
   def self.slugs
     dir = posts_dir
-    Dir.open(dir) do |d|
-      d.select do |o|
-        !%w[. .. .git].include?(o) and File.directory?("#{dir}/#{o}")
-      end
+    puts dir
+    Dir.open(dir).select do |o|
+      !%w[. .. .git].include?(o) and File.directory?("#{dir}/#{o}")
     end
   end
 
@@ -247,10 +245,8 @@ class Post
 
   def images_list
     dir = "#{Post.posts_dir}/#{slug}"
-    Dir.open(dir) do |d|
-      d.reject do |o|
-        %w[. .. manifest.json index.md draft_index.md].include?(o) or File.directory?("#{dir}/#{o}")
-      end
+    Dir.open(dir).reject do |o|
+      %w[. .. manifest.json index.md draft_index.md].include?(o) or File.directory?("#{dir}/#{o}")
     end
   end
 end

--- a/backend/app/models/tag.rb
+++ b/backend/app/models/tag.rb
@@ -1,15 +1,7 @@
 class Tag < ApplicationRecord
-  after_create do
-    notify_about_create_update_to_channel
-  end
-
-  after_update do
-    notify_about_create_update_to_channel
-  end
-
-  after_destroy do
-    notify_about_destroy_to_channel
-  end
+  after_create :notify_about_create_update_to_channel
+  after_update :notify_about_create_update_to_channel
+  after_destroy :notify_about_destroy_to_channel
 
   def notify_about_create_update_to_channel
     EntitiesChannel.broadcast_to(

--- a/backend/app/models/tag.rb
+++ b/backend/app/models/tag.rb
@@ -1,29 +1,36 @@
 class Tag < ApplicationRecord
   after_create do
-    notify_about_changes_to_channel 'create'
+    notify_about_create_update_to_channel
   end
 
   after_update do
-    notify_about_changes_to_channel 'update'
+    notify_about_create_update_to_channel
   end
 
   after_destroy do
-    notify_about_changes_to_channel 'destroy'
+    notify_about_destroy_to_channel
   end
 
-  def notify_about_changes_to_channel(action)
+  def notify_about_create_update_to_channel
     EntitiesChannel.broadcast_to(
       'all',
-      body: {
-        tag: JSON.parse(
-          ApplicationController.render(
-            partial: 'api/v1/tags/tag',
-            locals: {
-              tag: self,
-              destroy: action == 'destroy'
-            }
-          )
+      tag: JSON.parse(
+        ApplicationController.render(
+          partial: 'api/v1/tags/tag',
+          locals: {
+            tag: self
+          }
         )
+      )
+    )
+  end
+
+  def notify_about_destroy_to_channel
+    EntitiesChannel.broadcast_to(
+      'all',
+      tag: {
+        id: id,
+        _destroy: true
       }
     )
   end

--- a/backend/spec/controllers/api/v1/comments_controller_spec.rb
+++ b/backend/spec/controllers/api/v1/comments_controller_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'fakefs/spec_helpers'
+
+RSpec.describe Api::V1::CommentsController, type: :controller do
+  include ControllersHelpers
+  include FakeFS::SpecHelpers
+  render_views
+
+  let(:dir_name) { 'posts_dir' }
+  before do
+    request.accept = 'application/json'
+    allow_any_instance_of(Config::Options)
+      .to receive(:method_missing).with(:postsDir).and_return(dir_name)
+    allow_any_instance_of(Comment)
+      .to receive(:notify_about_create_update_to_channel).and_return(true)
+    allow_any_instance_of(Comment)
+      .to receive(:notify_about_destroy_to_channel).and_return(true)
+  end
+  before { FakeFS.activate! }
+  after { FakeFS.deactivate! }
+  let!(:user) { create(:user) }
+
+  describe ':create' do
+    let(:slug) { 'slug' }
+
+    before do
+      # TODO: Change to right route, after switch to bitia-rails gem
+      FakeFS::FileSystem.clone('./bitia-rails/app/views')
+      FakeFS::FileSystem.clone('./app/views')
+      allow_any_instance_of(Post).to receive(:push_to_git).and_return(true)
+      allow_any_instance_of(Authentication).to receive(:try_to_authenticate_user!).and_return(true)
+      Post.create!(slug: slug)
+    end
+
+    context "when user isn't signed in" do
+      before do
+        allow_any_instance_of(Authentication).to receive(:user_signed_in?).and_return(false)
+        allow_any_instance_of(Authentication).to receive(:current_user).and_return(nil)
+        post :create, params: { post_slug: slug, comment: { content: 'content' } }
+      end
+
+      it 'should success' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'should set user_id to nil' do
+        expect(parsed_response_body.dig('entities', 'comment', 'user_id'))
+          .to be_nil
+      end
+    end
+
+    context 'when user is signed in' do
+      before do
+        allow_any_instance_of(Authentication).to receive(:user_signed_in?).and_return(true)
+        allow_any_instance_of(Authentication).to receive(:current_user).and_return(user)
+        get :create, params: { post_slug: slug, comment: { content: 'content' } }
+      end
+
+      it 'should success' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'should set user_id to current_user id' do
+        expect(parsed_response_body.dig('entities', 'comment', 'user_id'))
+          .to eq user.id
+      end
+    end
+  end
+end

--- a/backend/spec/controllers/api/v1/comments_controller_spec.rb
+++ b/backend/spec/controllers/api/v1/comments_controller_spec.rb
@@ -5,6 +5,7 @@ require 'fakefs/spec_helpers'
 
 RSpec.describe Api::V1::CommentsController, type: :controller do
   include ControllersHelpers
+  include UserHelpers
   include FakeFS::SpecHelpers
   render_views
 
@@ -26,9 +27,7 @@ RSpec.describe Api::V1::CommentsController, type: :controller do
     let(:slug) { 'slug' }
 
     before do
-      # TODO: Change to right route, after switch to bitia-rails gem
-      FakeFS::FileSystem.clone('./bitia-rails/app/views')
-      FakeFS::FileSystem.clone('./app/views')
+      clone_views
       allow_any_instance_of(Post).to receive(:push_to_git).and_return(true)
       allow_any_instance_of(Authentication).to receive(:try_to_authenticate_user!).and_return(true)
       Post.create!(slug: slug)
@@ -36,8 +35,7 @@ RSpec.describe Api::V1::CommentsController, type: :controller do
 
     context "when user isn't signed in" do
       before do
-        allow_any_instance_of(Authentication).to receive(:user_signed_in?).and_return(false)
-        allow_any_instance_of(Authentication).to receive(:current_user).and_return(nil)
+        stub_user_not_authenticated
         post :create, params: { post_slug: slug, comment: { content: 'content' } }
       end
 
@@ -53,8 +51,7 @@ RSpec.describe Api::V1::CommentsController, type: :controller do
 
     context 'when user is signed in' do
       before do
-        allow_any_instance_of(Authentication).to receive(:user_signed_in?).and_return(true)
-        allow_any_instance_of(Authentication).to receive(:current_user).and_return(user)
+        stub_user_authenticated(user)
         get :create, params: { post_slug: slug, comment: { content: 'content' } }
       end
 

--- a/backend/spec/controllers/api/v1/posts/comments_controller_spec.rb
+++ b/backend/spec/controllers/api/v1/posts/comments_controller_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'fakefs/spec_helpers'
+
+RSpec.describe Api::V1::Posts::CommentsController, type: :controller do
+  include ControllersHelpers
+  include FakeFS::SpecHelpers
+  render_views
+
+  let(:dir_name) { 'posts_dir' }
+  before do
+    request.accept = 'application/json'
+    allow_any_instance_of(Config::Options)
+      .to receive(:method_missing).with(:postsDir).and_return(dir_name)
+    allow_any_instance_of(Comment)
+      .to receive(:notify_about_create_update_to_channel).and_return(true)
+    allow_any_instance_of(Comment)
+      .to receive(:notify_about_destroy_to_channel).and_return(true)
+  end
+  before { FakeFS.activate! }
+  after { FakeFS.deactivate! }
+  let!(:user) { create(:user) }
+  num_of_comments = 3
+  num_of_hidden_comments = 2
+
+  describe ':index' do
+    let(:slug) { 'slug' }
+    (1..num_of_comments).each do |i|
+      let!("comment#{i}".to_sym) { create(:comment, slug: slug, content: "Comment content#{i}") }
+    end
+    (1..num_of_hidden_comments).each do |i|
+      let!("comment#{i + num_of_comments}".to_sym) do
+        create(:comment, slug: slug, content: "Hidden comment content#{i}", hidden: true)
+      end
+    end
+    comments_content = (1..num_of_comments).map { |i| "Comment content#{i}" }
+    hidden_comments_content = (1..num_of_hidden_comments).map { |i| "Hidden comment content#{i}" }
+
+    before do
+      # TODO: Change to right route, after switch to bitia-rails gem
+      FakeFS::FileSystem.clone('./bitia-rails/app/views')
+      FakeFS::FileSystem.clone('./app/views')
+      allow_any_instance_of(Post).to receive(:push_to_git).and_return(true)
+      allow_any_instance_of(Authentication).to receive(:try_to_authenticate_user!).and_return(true)
+      Post.create!(slug: slug)
+    end
+
+    context "when user isn't signed in" do
+      before do
+        allow_any_instance_of(Authentication).to receive(:user_signed_in?).and_return(false)
+        allow_any_instance_of(Authentication).to receive(:current_user).and_return(nil)
+        get :index, params: { post_slug: slug }
+      end
+
+      it 'should success' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'should contain metadata with key all equals number of not hidden comments' do
+        expect(parsed_response_body.dig('metadata', 'all'))
+          .to eq num_of_comments + num_of_hidden_comments
+      end
+
+      it 'should contain entities with key comments and value type array' do
+        expect(parsed_response_body.dig('entities', 'comments')).to be_instance_of(Array)
+      end
+
+      it 'should contain entities with key comments and value array of not hidden comments' do
+        expect(
+          parsed_response_body
+            .dig('entities', 'comments')
+            .map { |comment| comment['content'] }
+        ).to match_array comments_content
+      end
+    end
+
+    context 'when user is signed in' do
+      before do
+        allow_any_instance_of(Authentication).to receive(:user_signed_in?).and_return(true)
+        allow_any_instance_of(Authentication).to receive(:current_user).and_return(user)
+        get :index, params: { post_slug: slug }
+      end
+
+      it 'should success' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'should contain metadata with key all equals number of all comments' do
+        expect(parsed_response_body.dig('metadata', 'all'))
+          .to eq num_of_comments + num_of_hidden_comments
+      end
+
+      it 'should contain entities with key comments and value type array' do
+        expect(parsed_response_body.dig('entities', 'comments')).to be_instance_of(Array)
+      end
+
+      it 'should contain entities with key comments and value array of all comments' do
+        expect(
+          parsed_response_body
+            .dig('entities', 'comments')
+            .map { |comment| comment['content'] }
+        ).to match_array comments_content + hidden_comments_content
+      end
+    end
+  end
+end

--- a/backend/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/backend/spec/controllers/api/v1/posts_controller_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'fakefs/spec_helpers'
+
+RSpec.describe Api::V1::PostsController, type: :controller do
+  include FakeFS::SpecHelpers
+
+  let(:dir_name) { 'posts_dir' }
+  before do
+    request.accept = 'application/json'
+    allow(Rails).to receive(:root).and_return('.')
+    allow_any_instance_of(Config::Options)
+      .to receive(:method_missing).with(:postsDir).and_return(dir_name)
+  end
+  before { FakeFS.activate! }
+  after { FakeFS.deactivate! }
+
+  describe ':image' do
+    let(:slug) { 'slug' }
+    let(:filename) { 'filename' }
+    let(:content) { 'content' }
+
+    before do
+      allow_any_instance_of(Post).to receive(:push_to_git).and_return(true)
+      post = Post.create!(slug: slug)
+      File.open('tempfile', 'w') { |f| f.write(content) }
+      post.images = [
+        ActionDispatch::Http::UploadedFile.new(
+          {
+            tempfile: File.open('tempfile', 'r'),
+            filename: filename
+          }
+        )
+      ]
+      get :image, params: { slug: slug, filename: filename }
+    end
+
+    it 'should success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'should return image file content' do
+      expect(response.body).to eq content
+    end
+  end
+end

--- a/backend/spec/factories/comment.rb
+++ b/backend/spec/factories/comment.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :comment do
+    content { 'Comment content' }
+  end
+end

--- a/backend/spec/factories/tag.rb
+++ b/backend/spec/factories/tag.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    text { 'tag' }
+  end
+end

--- a/backend/spec/factories/user.rb
+++ b/backend/spec/factories/user.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email { 'email@email.ru' }
+    password_digest { BCrypt::Password.create('123456') }
+  end
+end

--- a/backend/spec/helpers/controllers_helpers.rb
+++ b/backend/spec/helpers/controllers_helpers.rb
@@ -4,4 +4,10 @@ module ControllersHelpers
   def parsed_response_body
     JSON.parse(response.body)
   end
+
+  def clone_views
+    # TODO: Change to right route, after switch to bitia-rails gem
+    FakeFS::FileSystem.clone('./bitia-rails/app/views')
+    FakeFS::FileSystem.clone('./app/views')
+  end
 end

--- a/backend/spec/helpers/controllers_helpers.rb
+++ b/backend/spec/helpers/controllers_helpers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ControllersHelpers
+  def parsed_response_body
+    JSON.parse(response.body)
+  end
+end

--- a/backend/spec/helpers/user_helpers.rb
+++ b/backend/spec/helpers/user_helpers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module UserHelpers
+  def stub_user_not_authenticated
+    allow_any_instance_of(Authentication).to receive(:user_signed_in?).and_return(false)
+    allow_any_instance_of(Authentication).to receive(:current_user).and_return(nil)
+  end
+
+  def stub_user_authenticated(user)
+    allow_any_instance_of(Authentication).to receive(:user_signed_in?).and_return(true)
+    allow_any_instance_of(Authentication).to receive(:current_user).and_return(user)
+  end
+end

--- a/backend/spec/models/comment_spec.rb
+++ b/backend/spec/models/comment_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+require 'fakefs/spec_helpers'
+
+RSpec.describe Comment, type: :model do
+  let!(:comment) { create(:comment) }
+
+  describe '#valid?' do
+    context 'when author_name is nil' do
+      before do
+        comment.assign_attributes(author_name: nil)
+      end
+
+      it 'should return true' do
+        expect(comment.valid?).to eq true
+      end
+    end
+
+    context 'when author_name is invalid' do
+      before do
+        comment.assign_attributes(author_name: 'foo-bar')
+      end
+
+      it 'should return false' do
+        expect(comment.valid?).to eq false
+      end
+    end
+
+    context 'when author_name is valid' do
+      before do
+        comment.assign_attributes(author_name: 'foo_bar')
+      end
+
+      it 'should return true' do
+        expect(comment.valid?).to eq true
+      end
+    end
+
+    context 'when author_name is too short' do
+      before do
+        comment.assign_attributes(author_name: 'a')
+      end
+
+      it 'should return false' do
+        expect(comment.valid?).to eq false
+      end
+    end
+
+    context 'when content is not present' do
+      before do
+        comment.assign_attributes(content: nil)
+      end
+
+      it 'should return false' do
+        expect(comment.valid?).to eq false
+      end
+    end
+  end
+
+  describe '#notify_about_create_update_to_channel' do
+    context 'when comment is created' do
+      before do
+        allow(EntitiesChannel).to receive(:broadcast_to).and_return(true)
+        allow(ApplicationController).to receive(:render).and_return('{}')
+        Comment.create!(content: 'New comment')
+      end
+
+      it 'should be called and send data to channel' do
+        expect(EntitiesChannel).to have_received(:broadcast_to).with('all', { comment: {} })
+      end
+
+      it 'should generate right comment data' do
+        expect(ApplicationController).to have_received(:render)
+          .with(partial: 'api/v1/comments/comment', locals: { comment: Comment.last })
+      end
+    end
+
+    context 'when comment is updated' do
+      before do
+        allow(EntitiesChannel).to receive(:broadcast_to).and_return(true)
+        allow(ApplicationController).to receive(:render).and_return('{}')
+        comment.update(content: 'Updated comment')
+      end
+
+      it 'should be called and send data to channel' do
+        expect(EntitiesChannel).to have_received(:broadcast_to).with('all', { comment: {} })
+      end
+
+      it 'should generate right comment data' do
+        expect(ApplicationController).to have_received(:render)
+          .with(partial: 'api/v1/comments/comment', locals: { comment: comment })
+      end
+    end
+  end
+
+  describe '#notify_about_destroy_to_channel' do
+    context 'when comment is destroyed' do
+      before do
+        allow(EntitiesChannel).to receive(:broadcast_to).and_return(true)
+        comment.destroy!
+      end
+
+      it 'should be called and send data to channel' do
+        expect(EntitiesChannel).to have_received(:broadcast_to)
+          .with('all', { comment: { id: comment.id, _destroy: true } })
+      end
+    end
+  end
+end

--- a/backend/spec/models/post_spec.rb
+++ b/backend/spec/models/post_spec.rb
@@ -371,7 +371,10 @@ RSpec.describe Post, type: :model do
     context 'when arguments passed' do
       let(:tag) { 'tag' }
       before do
-        allow_any_instance_of(Tag).to receive(:notify_about_changes_to_channel).and_return(true)
+        allow_any_instance_of(Tag)
+          .to receive(:notify_about_create_update_to_channel).and_return(true)
+        allow_any_instance_of(Tag)
+          .to receive(:notify_about_destroy_to_channel).and_return(true)
         post.tags_attributes = [
           { text: tag }.stringify_keys
         ]

--- a/backend/spec/models/post_spec.rb
+++ b/backend/spec/models/post_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Post, type: :model do
   let(:slug) { slugs.first }
   let(:post) { described_class.new(post_data.merge!(slug: slug)) }
   let(:images) { %w[image1 image2 image3] }
+  let!(:user) { create(:user) }
 
   describe '#posts_dir' do
     context 'when dir exists' do
@@ -182,7 +183,6 @@ RSpec.describe Post, type: :model do
           .to receive(:method_missing).with(:postsDir).and_return("#{dir}/#{dir_name}")
         allow_any_instance_of(Config::Options)
           .to receive(:method_missing).with(:remoteName).and_return('origin')
-        User.create!(email: 'email@email.ru', password_digest: BCrypt::Password.create('123456'))
         FileUtils.mkdir_p("#{dir}/#{git_ref_dir}")
         # TODO: Find out why this fails
         # Git.init("#{dir}/#{git_ref_dir}", { bare: true })

--- a/backend/spec/models/post_spec.rb
+++ b/backend/spec/models/post_spec.rb
@@ -1,0 +1,242 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  let(:manifest) do
+    {
+      title: 'Post title',
+      published: false,
+      can_comment: 'authorized_only',
+      add_likes_auth_only: false,
+      num_of_likes: 57,
+      num_of_reposts: 57,
+      num_of_views: 57,
+      seo_title: 'SEO title',
+      seo_kw: %w[kw1 kw2],
+      created_at: DateTime.now,
+      updated_at: DateTime.now
+    }
+  end
+  let(:post) { manifest.merge!({ content: 'Post content' }) }
+  let(:slugs) { ['slug1', 'slug2', 'slug3'] }
+  let(:slug) { slugs.first }
+
+  describe '#posts_dir' do
+    let(:dir_name) { 'foo' }
+
+    before do
+      allow_any_instance_of(Config::Options)
+        .to receive(:method_missing).with(:postsDir).and_return(dir_name)
+      allow(FileUtils).to receive(:mkdir_p).with(dir_name).and_return(true)
+    end
+
+    context 'when dir exists' do
+      before do
+        allow(Dir).to receive(:exist?).with(dir_name).and_return(true)
+      end
+
+      it 'should return dir name' do
+        expect(described_class.posts_dir).to eq dir_name
+      end
+
+      it "shouldn't try to create dir" do
+        described_class.posts_dir
+        expect(FileUtils)
+          .not_to have_received(:mkdir_p)
+      end
+    end
+
+    context "when dir doesn't exist" do
+      before do
+        allow(Dir).to receive(:exist?).with(dir_name).and_return(false)
+      end
+
+      it 'should return dir name' do
+        expect(described_class.posts_dir).to eq dir_name
+      end
+
+      it 'should create dir' do
+        described_class.posts_dir
+        expect(FileUtils)
+          .to have_received(:mkdir_p).with(dir_name).once
+      end
+    end
+  end
+
+  describe '#all' do
+    before do
+      allow(described_class).to receive(:slugs).and_return(slugs)
+      slugs.each do |slug|
+        allow(described_class)
+          .to receive(:get_by_slug).with(slug).and_return(described_class.new(slug: slug))
+      end
+    end
+
+    it 'should return array of posts' do
+      expect(described_class.all)
+        .to all(be_an(described_class))
+    end
+
+    it 'should return array of posts with right slugs' do
+      expect(described_class.all.map(&:slug).sort)
+        .to eq(slugs)
+    end
+  end
+
+  describe '#get_by_slug' do
+    Dir.mktmpdir do |dir|
+      before do
+        allow_any_instance_of(Config::Options)
+          .to receive(:method_missing).with(:postsDir).and_return(dir)
+        FileUtils.mkdir_p("#{dir}/#{slug}")
+        File.open("#{dir}/#{slug}/manifest.json", 'w') do |f|
+          f.write(manifest.merge!({ published: published }).to_json)
+        end
+      end
+
+      context 'when post is published' do
+        let(:published) { true }
+        before do
+          File.open("#{dir}/#{slug}/index.md", 'w') do |f|
+            f.write(post[:content])
+          end
+        end
+
+        it 'should return post' do
+          expect(described_class.get_by_slug(slug)).to be_instance_of(Post)
+        end
+
+        it 'should have right title' do
+          expect(described_class.get_by_slug(slug).title).to eq(manifest[:title])
+        end
+
+        it 'should load content from index.md' do
+          expect(described_class.get_by_slug(slug).content).to eq(post[:content])
+        end
+      end
+
+      context "when post isn't published" do
+        let(:published) { false }
+        let(:draft_content) { "Draft #{post[:content]}" }
+        before do
+          File.open("#{dir}/#{slug}/draft_index.md", 'w') do |f|
+            f.write(draft_content)
+          end
+        end
+
+        it 'should return post' do
+          expect(described_class.get_by_slug(slug)).to be_instance_of(Post)
+        end
+
+        it 'should have right title' do
+          expect(described_class.get_by_slug(slug).title).to eq(manifest[:title])
+        end
+
+        it 'should load content from draft_index.md' do
+          expect(described_class.get_by_slug(slug).content).to eq(draft_content)
+        end
+      end
+    end
+  end
+
+  describe '#new' do
+    it 'should return post' do
+      expect(described_class.new()).to be_instance_of(Post)
+    end
+
+    it 'should have right title' do
+      expect(described_class.new(title: post[:title]).title).to eq(post[:title])
+    end
+
+    it 'should have published false' do
+      expect(described_class.new(title: post[:title]).published).to be false
+    end
+  end
+
+  describe '#slugs' do
+    Dir.mktmpdir do |dir|
+      before do
+        allow_any_instance_of(Config::Options)
+          .to receive(:method_missing).with(:postsDir).and_return(dir)
+        slugs.each { |slug| FileUtils.mkdir_p("#{dir}/#{slug}") }
+      end
+
+      it 'should return slugs' do
+        expect(described_class.slugs.sort).to eq slugs
+      end
+    end
+  end
+
+  describe '#images_list' do
+    let(:images) { %w[image1 image2 image3] }
+    Dir.mktmpdir do |dir|
+      before do
+        allow_any_instance_of(Config::Options)
+          .to receive(:method_missing).with(:postsDir).and_return(dir)
+        FileUtils.mkdir_p("#{dir}/#{slug}")
+        images.each { |image| File.open("#{dir}/#{slug}/#{image}", 'w') }
+      end
+
+      it 'should return images' do
+        expect(described_class.new(slug: slug).send(:images_list).sort).to eq images
+      end
+    end
+  end
+
+  describe '#push_to_git' do
+    # TODO: test push_to_git
+  end
+
+  describe '#save!' do
+    let(:new_post) { described_class.new(slug: slug, published: published) }
+    Dir.mktmpdir do |dir|
+      before do
+        allow_any_instance_of(Config::Options)
+          .to receive(:method_missing).with(:postsDir).and_return(dir)
+        allow_any_instance_of(described_class).to receive(:push_to_git).and_return(true)
+        new_post.save!
+      end
+
+      context 'when post is published' do
+        let(:published) { true }
+
+        it 'should create manifest.json' do
+          expect(File.exist?("#{dir}/#{slug}/manifest.json")).to be true
+        end
+
+        it 'should create index.md' do
+          expect(File.exist?("#{dir}/#{slug}/index.md")).to be true
+        end
+
+        it 'should set created_at to not nil value' do
+          expect(Post.get_by_slug(slug).created_at).not_to be_nil
+        end
+
+        it 'should push to git' do
+          expect(new_post)
+            .to have_received(:push_to_git).once
+        end
+      end
+
+      context "when post isn't published" do
+        let(:published) { false }
+
+        it 'should create manifest.json' do
+          expect(File.exist?("#{dir}/#{slug}/manifest.json")).to be true
+        end
+
+        it 'should create draft_index.md' do
+          expect(File.exist?("#{dir}/#{slug}/draft_index.md")).to be true
+        end
+
+        it 'should set created_at to not nil value' do
+          expect(Post.get_by_slug(slug).created_at).not_to be_nil
+        end
+
+        it 'should push to git' do
+          expect(new_post)
+            .to have_received(:push_to_git).once
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/models/tag_spec.rb
+++ b/backend/spec/models/tag_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+require 'fakefs/spec_helpers'
+
+RSpec.describe Tag, type: :model do
+  let!(:tag) { create(:tag) }
+
+  describe '#notify_about_create_update_to_channel' do
+    context 'when tag is created' do
+      before do
+        allow(EntitiesChannel).to receive(:broadcast_to).and_return(true)
+        allow(ApplicationController).to receive(:render).and_return('{}')
+        Tag.create!(text: 'new_tag')
+      end
+
+      it 'should be called and send data to channel' do
+        expect(EntitiesChannel).to have_received(:broadcast_to).with('all', { tag: {} })
+      end
+
+      it 'should generate right tag data' do
+        expect(ApplicationController).to have_received(:render)
+          .with(partial: 'api/v1/tags/tag', locals: { tag: Tag.last })
+      end
+    end
+
+    context 'when tag is updated' do
+      before do
+        allow(EntitiesChannel).to receive(:broadcast_to).and_return(true)
+        allow(ApplicationController).to receive(:render).and_return('{}')
+        tag.update(text: 'updated_tag')
+      end
+
+      it 'should be called and send data to channel' do
+        expect(EntitiesChannel).to have_received(:broadcast_to).with('all', { tag: {} })
+      end
+
+      it 'should generate right tag data' do
+        expect(ApplicationController).to have_received(:render)
+          .with(partial: 'api/v1/tags/tag', locals: { tag: tag })
+      end
+    end
+  end
+
+  describe '#notify_about_destroy_to_channel' do
+    context 'when tag is destroyed' do
+      before do
+        allow(EntitiesChannel).to receive(:broadcast_to).and_return(true)
+        tag.destroy!
+      end
+
+      it 'should be called and send data to channel' do
+        expect(EntitiesChannel).to have_received(:broadcast_to)
+          .with('all', { tag: { id: tag.id, _destroy: true } })
+      end
+    end
+  end
+end

--- a/backend/spec/models/tag_spec.rb
+++ b/backend/spec/models/tag_spec.rb
@@ -3,12 +3,17 @@ require 'fakefs/spec_helpers'
 
 RSpec.describe Tag, type: :model do
   let!(:tag) { create(:tag) }
+  before do
+    allow(EntitiesChannel).to receive(:broadcast_to).and_return(true)
+  end
 
   describe '#notify_about_create_update_to_channel' do
+    before do
+      allow(ApplicationController).to receive(:render).and_return('{}')
+    end
+
     context 'when tag is created' do
       before do
-        allow(EntitiesChannel).to receive(:broadcast_to).and_return(true)
-        allow(ApplicationController).to receive(:render).and_return('{}')
         Tag.create!(text: 'new_tag')
       end
 
@@ -24,8 +29,6 @@ RSpec.describe Tag, type: :model do
 
     context 'when tag is updated' do
       before do
-        allow(EntitiesChannel).to receive(:broadcast_to).and_return(true)
-        allow(ApplicationController).to receive(:render).and_return('{}')
         tag.update(text: 'updated_tag')
       end
 
@@ -43,7 +46,6 @@ RSpec.describe Tag, type: :model do
   describe '#notify_about_destroy_to_channel' do
     context 'when tag is destroyed' do
       before do
-        allow(EntitiesChannel).to receive(:broadcast_to).and_return(true)
         tag.destroy!
       end
 

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+require 'fakefs/spec_helpers'
+
+RSpec.describe User, type: :model do
+  let!(:user) { create(:user) }
+
+  describe '#valid?' do
+    context 'when email is already used' do
+      it 'should return false' do
+        expect(User.new(email: user.email, password_digest: user.password_digest).valid?)
+          .to eq false
+      end
+    end
+
+    context 'when password_digest length is not 60' do
+      before do
+        user.assign_attributes(password_digest: '123')
+      end
+
+      it 'should return false' do
+        expect(user.valid?).to eq false
+      end
+    end
+
+    context 'when email has wrong format' do
+      before do
+        user.assign_attributes(email: 'email')
+      end
+
+      it 'should return false' do
+        expect(user.valid?).to eq false
+      end
+    end
+
+    context 'when email is not set' do
+      before do
+        user.assign_attributes(email: nil)
+      end
+
+      it 'should return false' do
+        expect(user.valid?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Убираю пока WIP с mr. То, что предполагала сделать в рамках тикета, вроде сделала, но по реализации скорее всего будет еще много вопросов.
Сейчас валятся проверки на github, это связано с тем, что в Gemfile прописано использование гема bitia-rails версии 0.8.0, которой реально пока не существует. По идее после публикации этой версии гема, проверки должны пройти нормально

В рамках тикета добавлены тесты для основных методов моделей и контроллеров, которые на данный момент есть в проекте, КРОМЕ:
1) Если в контроллере явно не описаны методы create/update итд, то для них отдельных тестов не делается, считаем, что они реализованы на базе purable и такие ошибки должны отлавливаться либо тестами на модель(если например там по каким-то причинам переопределяются стандартные методы типа assign_attributes, save! итд), либо тестами на purable
2) Если метод очень простой и тест на него будет сложнее, чем сам метод (например не писала методы на получения всех тегов поста и на методы entity_params)
3) Не писала тестов на контроллер users, потому что он сейчас содержит много лишнего и логичнее отдельно сделать рефакторинг и вместе с этим написать тесты

см.комментарии ниже