### PR TITLE
WIP: MELQ-141: Refactor validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# REMOTE_REPO=../posts
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 /backups
 /sandbox
 /storage
+/posts
 /.env
 /db
 /.idea
 /gw-staging/frontends-playbook.yml
 /docker-compose.staging.yml
+/node_modules

--- a/auth/config/application.rb
+++ b/auth/config/application.rb
@@ -9,6 +9,7 @@ require 'action_controller/railtie'
 require 'action_mailer/railtie'
 require 'action_view/railtie'
 require 'action_cable/engine'
+require 'active_storage/engine'
 require 'rails/test_unit/railtie'
 
 # Require the gems listed in Gemfile, including any gems

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,12 +4,12 @@ FROM ruby:2.5.3-alpine3.8 AS base
 RUN apk add -U gmp-dev zlib libressl tzdata
 
 # install project-specific packages
-RUN apk add -U libpq postgresql-client imagemagick
+RUN apk add -U libpq postgresql-client imagemagick git
 WORKDIR /app
 
 FROM base AS builder
 
-RUN apk add -U gcc g++ make zlib-dev libressl-dev postgresql-dev git
+RUN apk add -U gcc g++ make zlib-dev libressl-dev postgresql-dev
 
 COPY Gemfile Gemfile.lock ./
 

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -60,3 +60,5 @@ gem 'google-cloud-storage'
 gem 'image_processing', '~> 1.2'
 
 gem 'redis-rails'
+
+gem 'git'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -106,6 +106,8 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
+    git (1.7.0)
+      rchardet (~> 1.8)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     google-api-client (0.28.7)
@@ -216,6 +218,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rchardet (1.8.0)
     redis (4.0.3)
     redis-actionpack (5.1.0)
       actionpack (>= 4.0, < 7)
@@ -320,6 +323,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   config
   factory_bot_rails
+  git
   google-cloud-storage
   image_processing (~> 1.2)
   jbuilder (~> 2.5)

--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -11,6 +11,13 @@ module Api
         resource
       end
 
+      def image
+        send_file(
+          "#{Rails.root}/storage/posts/#{params[:slug]}/#{params[:filename]}",
+          disposition: 'inline'
+        )
+      end
+
       def resource_id_name
         :slug
       end

--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -7,15 +7,8 @@ module Api
         @post = Post.find_by(slug: params[:slug])
       end
 
-      def update
-        params.dig(:post, :images_attachments_attributes)&.each do |attachment|
-          next unless (%i[id filename] - attachment.keys).empty?
-
-          blob = post.images.find_by(blob_id: attachment[:id]).blob
-          blob.filename = attachment[:filename]
-          blob.save!
-        end
-        super
+      def post
+        resource
       end
 
       def resource_id_name

--- a/backend/app/models/comment.rb
+++ b/backend/app/models/comment.rb
@@ -1,5 +1,4 @@
 class Comment < ApplicationRecord
-  belongs_to :post
   belongs_to :user, optional: true
   belongs_to :comment, optional: true
   has_one_attached :author_avatar

--- a/backend/app/models/like.rb
+++ b/backend/app/models/like.rb
@@ -1,3 +1,2 @@
 class Like < ApplicationRecord
-  belongs_to :post
 end

--- a/backend/app/models/no_db_model/base.rb
+++ b/backend/app/models/no_db_model/base.rb
@@ -1,0 +1,27 @@
+module NoDbModel
+  class Base
+    extend ActiveModel::Naming
+    extend ActiveModel::Translation
+    include ActiveModel::Validations
+    include ActiveModel::Conversion
+    include Validations
+
+    def initialize(params = {})
+      params.each do |attr, value|
+        self.public_send("#{attr}=", value)
+      end if params
+    end
+
+    def persisted?
+      false
+    end
+
+    def dir
+      model_name.name.constantize.send("#{model_name.plural}_dir")
+    end
+
+    def exist?
+      Dir.exist?("#{dir}/#{slug}")
+    end
+  end
+end

--- a/backend/app/models/no_db_model/validations.rb
+++ b/backend/app/models/no_db_model/validations.rb
@@ -1,0 +1,39 @@
+module NoDbModel
+  module Validations
+    class UniquenessValidator < ActiveModel::EachValidator
+      def initialize(options)
+        if options[:conditions] && !options[:conditions].respond_to?(:call)
+          raise ArgumentError, "#{options[:conditions]} was passed as :conditions but is not callable. " \
+                               "Pass a callable instead: `conditions: -> { where(approved: true) }`"
+        end
+        unless Array(options[:scope]).all? { |scope| scope.respond_to?(:to_sym) }
+          raise ArgumentError, "#{options[:scope]} is not supported format for :scope option. " \
+            "Pass a symbol or an array of symbols instead: `scope: :user_id`"
+        end
+        super({ case_sensitive: true }.merge!(options))
+        @klass = options[:class]
+      end
+
+      def validate_each(record, attribute, value)
+        puts "validate_each"
+        puts record
+        puts attribute
+        puts value
+        puts options
+
+        if record.exist?
+          error_options = options.except(:case_sensitive, :scope, :conditions)
+          error_options[:value] = value
+
+          record.errors.add(attribute, :taken, error_options)
+        end
+      end
+    end
+
+    module ClassMethods
+      def validates_uniqueness_of(*attr_names)
+        validates_with UniquenessValidator, _merge_attributes(attr_names)
+      end
+    end
+  end
+end

--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -1,23 +1,256 @@
-class Post < ApplicationRecord
-  has_many_attached :images
-  has_and_belongs_to_many :tags
-  has_many :comments
-  enum can_comment: %w[authorized_only everyone nobody]
-    .each_with_object({}) { |v, a| a[v.to_sym] = v }
-
-  accepts_nested_attributes_for :tags, allow_destroy: true
-  accepts_nested_attributes_for :images_attachments, allow_destroy: true
-
-  validates(
+class Post
+  attr_accessor(
+    :title,
+    :content,
+    :published,
+    :can_comment,
+    :add_likes_auth_only,
+    :num_of_likes,
+    :num_of_reposts,
+    :num_of_views,
     :slug,
-    uniqueness: {
-      message: 'Slug должен быть уникален'
-    }
+    :seo_title,
+    :seo_kw,
+    :created_at,
+    :updated_at
   )
-  validates(
-    :slug,
-    presence: {
-      message: 'Обязательное поле'
+
+  def initialize(*args)
+    post = args.empty? ? {} : args[0]
+    @title = post[:title]
+    @content = post[:content]
+    @published = post.fetch(:published, false)
+    @can_comment = post.fetch(:can_comment, 'authorized_only')
+    @add_likes_auth_only = post.fetch(:add_likes_auth_only, false)
+    @num_of_likes = post.fetch(:num_of_likes, 0)
+    @num_of_reposts = post.fetch(:num_of_reposts, 0)
+    @num_of_views = post.fetch(:num_of_views, 0)
+    @slug = post[:slug]
+    @seo_title = post[:seo_title]
+    @seo_kw = post[:seo_kw] || []
+    @created_at = post[:created_at]&.to_datetime
+    @updated_at = post[:updated_at]&.to_datetime
+  end
+
+  def self.posts_dir
+    FileUtils.mkdir_p Settings.postsDir unless Dir.exist?(Settings.postsDir)
+
+    Settings.postsDir
+  end
+
+  def self.all
+    slugs.map do |slug|
+      Post.get_by_slug(slug)
+    end
+  end
+
+  def self.find_by(*args)
+    params = args.empty? ? {} : args[0]
+
+    raise ArgumentError, 'Args empty' if params.keys.empty?
+
+    primary_key = params.keys.first
+    raise StandardError, 'Not Implemented' if params.keys.length > 1 || primary_key != :slug
+
+    Post.get_by_slug(params[:slug])
+  end
+
+  def attributes
+    as_json
+  end
+
+  def tags
+    PostsTag.where(post_slug: slug).map(&:tag)
+  end
+
+  def images
+    images_list.each_with_index.map do |img, id|
+      {
+        id: id,
+        filename: img,
+        url: "/api/v1/posts/#{slug}/images/#{img}"
+      }
+    end
+  end
+
+  def images_attachments_attributes=(*args)
+    params = args.empty? ? [] : args[0]
+    raise StandardError, 'Args empty' if params.empty?
+
+    list = images_list
+    dir = "#{Post.posts_dir}/#{slug}"
+    params.each do |image|
+      next unless image.include?('id')
+
+      if image.include?('_destroy') && image['_destroy'] == 'true'
+        FileUtils.rm("#{dir}/#{list[image['id'].to_i]}")
+      else
+        File.rename("#{dir}/#{list[image['id'].to_i]}", "#{dir}/#{image['filename']}")
+      end
+    end
+  end
+
+  def comments
+    Comment.where(post_slug: slug)
+  end
+
+  def valid?(context = :create)
+    return false unless slug.present?
+
+    return false if context == :create && Post.slugs.include?(slug)
+
+    return false unless %w[authorized_only everyone nobody].include?(can_comment)
+
+    true
+  end
+
+  def assign_attributes(*args)
+    params = args.empty? ? {} : args[0]
+
+    raise StandardError, 'Args empty' if params.keys.empty?
+
+    self.slug = params['slug'] unless slug
+    if params.include?('images_attachments_attributes')
+      self.images_attachments_attributes = params['images_attachments_attributes']
+    end
+    params.each do |k, v|
+      next if k == 'images_attachments_attributes'
+
+      send("#{k}=", v)
+    end
+
+    self
+  end
+
+  def images=(*args)
+    params = args.empty? ? [] : args[0]
+    raise StandardError, 'Args empty' if params.empty?
+
+    dir = "#{Settings.postsDir}/#{slug}"
+    FileUtils.mkdir_p dir unless Dir.exist?(dir)
+    params.each do |image|
+      # TODO: copy file with cp
+      image_data = File.open(image.tempfile.path, 'r', &:read)
+      File.open("#{dir}/#{image.original_filename}", 'w') do |f|
+        f.write(image_data)
+      end
+    end
+  end
+
+  def tag_ids=(*args)
+    # Rails use this method for nested CRUD
+    # We don't use accepts_nested_attributes_for for tags, so this method is unused
+  end
+
+  def tags_attributes=(*args)
+    params = args.empty? ? [] : args[0]
+    raise StandardError, 'Args empty' if params.empty?
+
+    params.each do |tag|
+      if tag.include?('id')
+        if tag['_destroy'] == 'true'
+          PostsTag.where(tag_id: tag['id'], post_slug: slug).destroy_all
+          Tag.find(tag['id']).destroy! unless PostsTag.where(tag_id: tag['id']).exists?
+        else
+          unless PostsTag.where(tag_id: tag['id'], post_slug: slug).exists?
+            PostsTag.create!(tag_id: tag['id'], post_slug: slug)
+          end
+        end
+      else
+        PostsTag.create!(tag: Tag.create!(text: tag['text']), post_slug: slug)
+      end
+    end
+  end
+
+  def save!
+    dir = "#{Settings.postsDir}/#{slug}"
+    FileUtils.mkdir_p dir unless Dir.exist?(dir)
+
+    @created_at = DateTime.now if created_at.nil?
+    @updated_at = DateTime.now
+    manifest = {
+      title: title,
+      published: published,
+      can_comment: can_comment,
+      add_likes_auth_only: add_likes_auth_only,
+      num_of_likes: num_of_likes,
+      num_of_reposts: num_of_reposts,
+      num_of_views: num_of_views,
+      seo_title: seo_title,
+      seo_kw: seo_kw,
+      created_at: created_at,
+      updated_at: updated_at
     }
-  )
+    File.open("#{dir}/manifest.json", 'w') do |f|
+      f.write(manifest.to_json)
+    end
+
+    File.open("#{dir}/#{published ? '' : 'draft_'}index.md", 'w') do |f|
+      f.write(content)
+    end
+
+    push_to_git
+
+    self
+  end
+
+  def self.create!(*args)
+    post = Post.new(*args)
+    raise StandardError, 'Post not valid' unless post.valid?
+
+    post.save!
+  end
+
+  def destroy!
+    FileUtils.rm_rf("#{Settings.postsDir}/#{slug}")
+    PostsTag.where(post_slug: slug).each do |pt|
+      pt.destroy!
+      pt.tag.destroy! unless PostsTag.where(tag: pt.tag).exists?
+    end
+    push_to_git
+
+    self
+  end
+
+  def push_to_git
+    g = Git.open(Post.posts_dir, log: Logger.new(STDOUT))
+    g.config('user.name', 'Root')
+    g.config('user.email', User.first.email)
+    g.add(all: true)
+    g.commit("Update posts #{DateTime.now}")
+    g.push(g.remote(Settings.remoteName))
+  end
+
+  def self.slugs
+    dir = posts_dir
+    Dir.open(dir) do |d|
+      d.select do |o|
+        !%w[. .. .git].include?(o) and File.directory?("#{dir}/#{o}")
+      end
+    end
+  end
+
+  def self.get_by_slug(slug)
+    dir = "#{Settings.postsDir}/#{slug}"
+    manifest = File.open("#{dir}/manifest.json", 'r') do |f|
+      JSON.parse(f.read)
+    end
+    Post.new(
+      manifest.symbolize_keys.merge(
+        slug: slug,
+        content: File.open("#{dir}/#{manifest['published'] ? '' : 'draft_'}index.md", 'r', &:read)
+      )
+    )
+  end
+
+  private
+
+  def images_list
+    dir = "#{Post.posts_dir}/#{slug}"
+    Dir.open(dir) do |d|
+      d.reject do |o|
+        %w[. .. manifest.json index.md draft_index.md].include?(o) or File.directory?("#{dir}/#{o}")
+      end
+    end
+  end
 end

--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -1,4 +1,4 @@
-class Post
+class Post < NoDbModel::Base
   attr_accessor(
     :title,
     :content,
@@ -13,6 +13,14 @@ class Post
     :seo_kw,
     :created_at,
     :updated_at
+  )
+
+  validates :slug, presence: true
+  validates(
+    :slug,
+    uniqueness: {
+      message: 'Slug должен быть уникален'
+    }
   )
 
   def initialize(*args)
@@ -94,15 +102,15 @@ class Post
     Comment.where(post_slug: slug)
   end
 
-  def valid?(context = :create)
-    return false unless slug.present?
+  #def valid?(context = :create)
+  #  return false unless slug.present?
 
-    return false if context == :create && Post.slugs.include?(slug)
+  #  return false if context == :create && Post.slugs.include?(slug)
 
-    return false unless %w[authorized_only everyone nobody].include?(can_comment)
+  #  return false unless %w[authorized_only everyone nobody].include?(can_comment)
 
-    true
-  end
+  #  true
+  #end
 
   def assign_attributes(*args)
     params = args.empty? ? {} : args[0]

--- a/backend/app/models/posts_tag.rb
+++ b/backend/app/models/posts_tag.rb
@@ -1,0 +1,4 @@
+# Posts-to-tags many-to-many linking model
+class PostsTag < ApplicationRecord
+  belongs_to :tag
+end

--- a/backend/app/models/tag.rb
+++ b/backend/app/models/tag.rb
@@ -1,2 +1,30 @@
 class Tag < ApplicationRecord
+  after_create do
+    notify_about_changes_to_channel 'create'
+  end
+
+  after_update do
+    notify_about_changes_to_channel 'update'
+  end
+
+  after_destroy do
+    notify_about_changes_to_channel 'destroy'
+  end
+
+  def notify_about_changes_to_channel(action)
+    EntitiesChannel.broadcast_to(
+      'all',
+      body: {
+        tag: JSON.parse(
+          ApplicationController.render(
+            partial: 'api/v1/tags/tag',
+            locals: {
+              tag: self,
+              destroy: action == 'destroy'
+            }
+          )
+        )
+      }
+    )
+  end
 end

--- a/backend/app/models/tag.rb
+++ b/backend/app/models/tag.rb
@@ -1,3 +1,2 @@
 class Tag < ApplicationRecord
-  has_and_belongs_to_many :posts
 end

--- a/backend/app/views/api/v1/posts/_image.json.jbuilder
+++ b/backend/app/views/api/v1/posts/_image.json.jbuilder
@@ -1,5 +1,5 @@
 json.merge!(
-  id: image.id,
-  original_filename: image.filename.to_s,
-  url: polymorphic_url(image, only_path: true)
+  id: image[:id],
+  original_filename: image[:filename],
+  url: image[:url]
 )

--- a/backend/app/views/api/v1/tags/_tag.json.jbuilder
+++ b/backend/app/views/api/v1/tags/_tag.json.jbuilder
@@ -1,1 +1,3 @@
 json.merge! tag.attributes
+
+json.merge!(_destroy: true) if defined?(destroy) && destroy

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       resources :posts, param: :slug do
         resources :comments, module: :posts, only: %i[index]
       end
+      get '/posts/:slug/images/:filename', to: 'posts#image', constraints: { filename: /.+/ }
       resources :comments
       resources :tags
     end

--- a/backend/config/settings/development.yml
+++ b/backend/config/settings/development.yml
@@ -1,1 +1,3 @@
 emailFrom: 'maxilex-test@yandex.ru'
+postsDir: './storage/posts'
+remoteName: <%= ENV.fetch('REMOTE_NAME', 'origin') %>

--- a/backend/config/settings/production.yml
+++ b/backend/config/settings/production.yml
@@ -1,1 +1,3 @@
 emailFrom: 'contact@contact.ru'
+postsDir: './storage/posts'
+remoteName: <%= ENV.fetch('REMOTE_NAME', 'origin') %>

--- a/backend/db/migrate/20181109115711_initial_migration.rb
+++ b/backend/db/migrate/20181109115711_initial_migration.rb
@@ -27,33 +27,6 @@ class InitialMigration < ActiveRecord::Migration[5.2]
         ADD CONSTRAINT user_password_digest_length CHECK(char_length(password_digest) = 60);
     DDL
 
-    execute <<-DDL
-      CREATE TYPE can_comment AS ENUM (
-        'authorized_only', 'everyone', 'nobody'
-      );
-    DDL
-
-    create_table :posts do |t|
-      t.string :title
-      t.text :content
-      t.boolean :published, default: false
-      t.column :can_comment, :can_comment, default: 'authorized_only'
-      t.boolean :add_likes_auth_only, default: false
-      t.integer :num_of_likes
-      t.integer :num_of_reposts
-      t.integer :num_of_views
-      t.string :slug, null: false
-      t.string :seo_title
-      t.jsonb :seo_kw, default: []
-
-      t.timestamps
-    end
-
-    execute <<-DDL
-      ALTER TABLE posts
-        ADD CONSTRAINT post_slug_unique UNIQUE (slug);
-    DDL
-
     create_table :tags do |t|
       t.string :text
     end
@@ -76,7 +49,7 @@ class InitialMigration < ActiveRecord::Migration[5.2]
     DDL
 
     create_table :comments do |t|
-      t.belongs_to :post
+      t.string :post_slug
       t.belongs_to :comment
       t.belongs_to :user
       t.text :content, null: false
@@ -94,7 +67,7 @@ class InitialMigration < ActiveRecord::Migration[5.2]
     DDL
 
     create_table :likes do |t|
-      t.belongs_to :post
+      t.string :post_slug
       t.jsonb :user_data
     end
 

--- a/backend/db/migrate/20181109115711_initial_migration.rb
+++ b/backend/db/migrate/20181109115711_initial_migration.rb
@@ -36,8 +36,8 @@ class InitialMigration < ActiveRecord::Migration[5.2]
         ADD CONSTRAINT tag_unique UNIQUE (text);
     DDL
 
-    create_table :posts_tags, id: false do |t|
-      t.belongs_to :post
+    create_table :posts_tags do |t|
+      t.string :post_slug
       t.belongs_to :tag
     end
 

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -16,11 +16,13 @@ Setting.create!(
 Post.create!(
   slug: 'about-blog-slug',
   title: 'About blog',
-  content: 'About blog'
+  content: 'About blog',
+  published: true
 )
 
 Post.create!(
   slug: 'privacy-policy-slug',
   title: 'Privacy policy',
-  content: 'Privacy policy'
+  content: 'Privacy policy',
+  published: true
 )

--- a/backend/spec/concerns/purable_spec.rb
+++ b/backend/spec/concerns/purable_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 
-
 class Anonymou
   def self.all
     [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377]
@@ -10,7 +9,6 @@ class Anonymou
     all[id.to_i]
   end
 end
-
 
 RSpec.describe Purable, type: :controller do
   controller(ActionController::Base) do

--- a/backend/spec/concerns/resourceable_spec.rb
+++ b/backend/spec/concerns/resourceable_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 
-
 RSpec.describe Resourceable do
   let(:resource_example) { 42 }
   let(:resources_example) { [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377] }

--- a/backend/spec/support/factory_bot.rb
+++ b/backend/spec/support/factory_bot.rb
@@ -1,4 +1,3 @@
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end
-

--- a/convert_md_post_by_slug_to_html.js
+++ b/convert_md_post_by_slug_to_html.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const marked = require('marked');
+
+const slug = process.argv[2];
+if (slug === undefined) {
+  throw new Error('Slug is not set');
+}
+const dirFrom = process.argv[3] || './storage/posts';
+
+fs.access(
+  `${dirFrom}/${slug}/index.md`,
+  fs.F_OK,
+  (err) => {
+    if (err) {
+      throw new Error(err);
+    }
+
+    const content = fs.readFileSync(`${dirFrom}/${slug}/index.md`, 'utf8');
+    console.log(marked(content));
+  },
+);

--- a/convert_md_posts_to_html.sh
+++ b/convert_md_posts_to_html.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+DIR_FROM=${1:-./storage/posts}
+shift
+DIR_TO=${1:-./published_posts}
+
+if [[ ! -d "$DIR_FROM" ]]; then
+  echo "Directory $DIR_FROM doesn't exist" 1>&2
+  exit 1
+fi
+
+RESULT=0
+for POST_DIR in "$DIR_FROM"/*; do
+  if [[ -f "$POST_DIR/index.md" ]]; then
+    SLUG="$(basename $POST_DIR)"
+    mkdir -p "$DIR_TO/$SLUG"
+    node ./convert_md_post_by_slug_to_html.js "$SLUG" "$DIR_FROM" > "$DIR_TO/$SLUG/index.html"
+    STATUS=$?
+    [[ $STATUS = 1 || $RESULT = 1 ]] && RESULT=1 || RESULT=0
+    if (( $STATUS == 0 )); then
+      echo Post with slug $SLUG converted successfully
+    else
+      echo Post with slug $SLUG converted failed
+    fi
+    rsync -a --exclude="index.md" --exclude="manifest.json" --exclude="draft_index.md" "$POST_DIR/" "$DIR_TO/$SLUG"
+  fi
+done
+
+exit $RESULT
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,12 +43,15 @@ services:
       RAILS_LOG_TO_STDOUT: ${RAILS_LOG_TO_STDOUT:-1}
       SENTRY_DSN: ${SENTRY_DSN:-https://abec18ecbeff4999be7e4202dc8efc38:0910a5fe4f154c17a4f8bfd9206592e4@bugs.bitia.ru/11}
       EMAIL_PASSWORD: ${EMAIL_PASSWORD:-123456}
+      GIT_PATH: ${GIT_PATH:-/usr/bin}
+      REMOTE_NAME: ${REMOTE_NAME:-origin}
     links:
       - db
       - redis
     volumes:
       - ${PWD}/storage:/app/storage
-      - ${PWD}/backend:/app
+      - ${PWD}/posts:/app/posts
+      - ${PWD}/backend/app:/app/app
   job:
     build: ./backend
     network_mode: bridge

--- a/frontend/src/v1/components/CommentForm/CommentForm.js
+++ b/frontend/src/v1/components/CommentForm/CommentForm.js
@@ -24,7 +24,7 @@ class CommentForm extends React.PureComponent {
         comment: {
           ...this.state.comment,
           comment_id: this.props.responseToCommentId,
-          post_id: this.props.posts[slug].id,
+          post_slug: slug,
         },
       },
       () => {
@@ -88,7 +88,6 @@ CommentForm.propTypes = {
   createComment: PropTypes.func,
   responseToCommentId: PropTypes.number,
   afterSubmit: PropTypes.func,
-  posts: PropTypes.object,
 };
 
 const mapStateToProps = state => ({ posts: state.postsStoreV1.posts });

--- a/frontend/src/v1/redux/tags/reducer.js
+++ b/frontend/src/v1/redux/tags/reducer.js
@@ -35,6 +35,12 @@ const tagsReducer = (
       ),
       numOfActiveRequests: state.numOfActiveRequests - 1,
     };
+  case acts.REMOVE_TAG_SUCCESS:
+    return {
+      ...state,
+      tags: R.dissoc(action.id, state.tags),
+      numOfActiveRequests: state.numOfActiveRequests - 1,
+    };
   default:
     return state;
   }

--- a/frontend/src/v1/utils/entity_processors/tag_processor.js
+++ b/frontend/src/v1/utils/entity_processors/tag_processor.js
@@ -1,6 +1,13 @@
 import acts from '@/v1/redux/tags/acts';
 
 const tagProcessor = (dispatch, tag) => {
+  if (tag._destroy) { // eslint-disable-line no-underscore-dangle
+    dispatch({
+      type: acts.REMOVE_TAG_SUCCESS,
+      id: tag.id,
+    });
+    return;
+  }
   dispatch({
     type: acts.LOAD_TAGS_SUCCESS,
     tag,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "marked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.0.tgz",
+      "integrity": "sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA=="
+    }
+  }
+}

--- a/prepare_remote_rep.sh
+++ b/prepare_remote_rep.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+if [ -n "$REMOTE_REPO" ]
+then
+  mkdir -p storage
+  cd ../storage
+  git clone $REMOTE_REPO posts
+else
+  mkdir -p posts
+  cd posts
+  git init --bare
+  cd ..
+  mkdir -p storage
+  cd ./storage
+  git clone ../posts
+fi
+cd posts
+if [ -n "$REMOTE_NAME" ]
+then
+  git remote set-url $REMOTE_NAME ./posts
+else
+  git remote set-url origin ./posts
+fi
+


### PR DESCRIPTION
Для валидации полей, которые не завязаны на базу данных типа presence, действительно достаточно подключить ActiveModel::Validations, но вот с валидацией, которая завязана на базу, возникают проблемы. В ActiveRecord для валидации инклюдится ActiveModel::Validations и реализуются отдельно 
require "active_record/validations/associated"
require "active_record/validations/uniqueness"
require "active_record/validations/presence"
require "active_record/validations/absence"
require "active_record/validations/length"
Насколько я понимаю, здесь например presence наследуется от ActiveModel::Validations::PresenceValidator и  нужен для того, чтобы проверять наличие для моделей, которые связаны через belong_to

Получается, что если мы хотим хранить данные вне базы и иметь те же самые валидаторы, их надо реализовать отдельно и подключить вместе с ActiveModel::Validations, причем так, чтобы эти валидаторы наследовались от валидаторов из ActiveModel::Validations, тогда по идее интерфейс общения с этими валидаторами на уровне модели останется тем же, что и был