### PR TITLE
MELQ-146: Сделать страницу просмотра списка постов в соответствии с дизайном

### DIFF
--- a/frontend/src/v1/layouts/MainScreen/MainScreen.jsx
+++ b/frontend/src/v1/layouts/MainScreen/MainScreen.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { css, StyleSheet } from '../../aphrodite';
 import withModals, { ModalContainerContext } from '../../modules/modalable';
 import { closeUserSession } from '@/v1/utils/auth';
+
+import { setEditMode as setEditModeAction } from '../../redux/editMode/actions';
 
 import LogInForm from '../../forms/LogInForm/LogInForm';
 import AdminPanel from './panels/AdminPanel';
@@ -43,18 +47,13 @@ class MainScreen extends React.PureComponent {
     };
   }
 
-  constructor(props) {
-    super(props);
-    this.state = { editMode: false };
-  }
-
   renderPanel = () => {
-    const { editMode } = this.state;
-    if (this.props.user) {
+    const { editMode, user, setEditMode } = this.props;
+    if (user) {
       return (
         <AdminPanel
           editMode={editMode}
-          switchEditMode={() => this.setState({ editMode: !editMode })}
+          switchEditMode={() => setEditMode(!editMode) }
           logOut={closeUserSession}
         />
       );
@@ -63,14 +62,14 @@ class MainScreen extends React.PureComponent {
   };
 
   renderHeader = () => {
-    if (this.state.editMode) {
+    if (this.props.editMode) {
       return <EditModeHeader addNewPost={() => this.props.history.push('/new')} />;
     }
     return <DefaultHeader />;
   };
 
   render() {
-    const { children, header } = this.props;
+    const { children } = this.props;
 
     return (
       <ModalContainerContext.Consumer>
@@ -101,4 +100,18 @@ class MainScreen extends React.PureComponent {
   }
 }
 
-export default withRouter(withModals(MainScreen));
+MainScreen.propTypes = {
+  editMode: PropTypes.bool,
+  setEditMode: PropTypes.func,
+  children: PropTypes.node,
+  history: PropTypes.object,
+  user: PropTypes.object,
+};
+
+const mapStateToProps = state => ({ editMode: state.editMode });
+
+const mapDispatchToProps = dispatch => (
+  { setEditMode: editMode => dispatch(setEditModeAction(editMode)) }
+);
+
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(withModals(MainScreen)));

--- a/frontend/src/v1/reducers.js
+++ b/frontend/src/v1/reducers.js
@@ -5,6 +5,7 @@ import { default as postsReducerV1 } from '@/v1/redux/posts/reducer';
 import { default as commentsReducerV1 } from '@/v1/redux/comments/reducer';
 import { default as tagsReducerV1 } from '@/v1/redux/tags/reducer';
 import { default as userSessionReducerV1 } from '@/v1/redux/user_session/reducer';
+import { default as editModeReducerV1 } from '@/v1/redux/editMode/reducer';
 
 export default combineReducers({
   usersStoreV1: usersReducerV1,
@@ -13,4 +14,5 @@ export default combineReducers({
   tagsStoreV1: tagsReducerV1,
   userSessionV1: userSessionReducerV1,
   form: formReducer,
+  editMode: editModeReducerV1,
 });

--- a/frontend/src/v1/redux/editMode/actions.js
+++ b/frontend/src/v1/redux/editMode/actions.js
@@ -1,0 +1,8 @@
+import acts from './acts';
+
+export const setEditMode = editMode => ({
+  type: acts.SET_EDIT_MODE,
+  editMode,
+});
+
+export default setEditMode;

--- a/frontend/src/v1/redux/editMode/acts.js
+++ b/frontend/src/v1/redux/editMode/acts.js
@@ -1,0 +1,3 @@
+const acts = { SET_EDIT_MODE: 'SET_EDIT_MODE_V1' };
+
+export default acts;

--- a/frontend/src/v1/redux/editMode/reducer.js
+++ b/frontend/src/v1/redux/editMode/reducer.js
@@ -1,0 +1,12 @@
+import acts from './acts';
+
+const editModeReducer = (state = false, action) => {
+  switch (action.type) {
+  case acts.SET_EDIT_MODE:
+    return action.editMode;
+  default:
+    return state;
+  }
+};
+
+export default editModeReducer;

--- a/frontend/src/v1/screens/MainPage.jsx
+++ b/frontend/src/v1/screens/MainPage.jsx
@@ -1,43 +1,109 @@
 import React from 'react';
-import { withRouter, Link } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import * as R from 'ramda';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import MainScreen from '../layouts/MainScreen/MainScreen';
+
+import { css, StyleSheet } from '../aphrodite';
+
 import { currentUser } from '@/v1/redux/user_session/utils';
 import { loadPosts } from '@/v1/redux/posts/actions';
 
+import MainScreen from '../layouts/MainScreen/MainScreen';
+import PostCard from '../components/PostCard/PostCard';
+import Button from '../components/Button/Button';
+
+const mapIndexed = R.addIndex(R.map);
+
+const btns = [
+  {
+    text: 'Опубликованные',
+    style: 'info',
+  },
+  { text: 'Черновики' },
+];
+
+const styles = StyleSheet.create({
+  cardsWrapper: {
+    marginTop: -2,
+    marginLeft: -32,
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  },
+  defaultHeader: { marginTop: 12 },
+  editModeHeader: { marginTop: 30 },
+  btnsContainer: { width: 289 },
+});
 
 class MainPage extends React.PureComponent {
   componentDidMount() {
     this.props.loadPosts();
   }
 
+  onCardClick = (post, e, target) => {
+    e.stopPropagation();
+    switch (target) {
+    case 'like':
+      console.log('Click on like counter');
+      break;
+    case 'comment':
+      console.log('Redirect to comment');
+      break;
+    case 'share':
+      console.log('Share post');
+      break;
+    default:
+      this.props.history.push(`/${post.slug}`);
+    }
+  };
+
   render() {
-    const { user, posts } = this.props;
+    const { user, posts, editMode } = this.props;
 
     return (
       <MainScreen header="" user={user}>
-        {
-          R.map(
-            post => (
-              <div key={post.slug}>
-                <h2>{post.title}</h2>
-                <div>{post.updated_at}</div>
-                <div>{`Tags: ${R.join(', ', R.map(tag => tag.text, post.tags))}`}</div>
-                <div>{`Likes: ${post.num_of_likes || 0}`}</div>
-                <div>{`Reposts: ${post.num_of_reposts || 0}`}</div>
-                <div>{`Views: ${post.num_of_views || 0}`}</div>
-                <div>
-                  <Link to={`/${post.slug}`}>Open</Link>
-                  |
-                  <Link to={`/${post.slug}/edit`}>Edit</Link>
-                </div>
+        <div className={css(styles.defaultHeader, editMode && styles.editModeHeader)}>
+          {
+            editMode && (
+              <div className={css(styles.btnsContainer)}>
+                <Button
+                  onClick={() => {}}
+                  size="big"
+                  tooltipText={R.map(btn => btn.tooltipText, btns)}
+                  tooltipSide={R.map(btn => btn.tooltipSide, btns)}
+                  disabled={R.map(btn => btn.disabled, btns)}
+                  btnStyle={R.map(btn => btn.style, btns)}
+                  isWaiting={R.map(btn => btn.isWaiting, btns)}
+                >
+                  {
+                    mapIndexed(
+                      (btn, index) => (
+                        <div key={index}>{btn.text}</div>
+                      ),
+                      btns,
+                    )
+                  }
+                </Button>
               </div>
-            ),
-            R.values(posts),
-          )
-        }
+            )
+          }
+        </div>
+        <div className={css(styles.cardsWrapper)}>
+          {
+            R.map(
+              post => (
+                <PostCard
+                  post={post}
+                  onClick={(e, target) => this.onCardClick(post, e, target)}
+                  disabledCounter={false}
+                  key={post.id}
+                />
+              ),
+              R.values(posts),
+            )
+          }
+        </div>
       </MainScreen>
     );
   }
@@ -46,11 +112,15 @@ class MainPage extends React.PureComponent {
 MainPage.propTypes = {
   user: PropTypes.object,
   posts: PropTypes.object,
+  editMode: PropTypes.bool,
+  history: PropTypes.object,
+  loadPosts: PropTypes.func,
 };
 
 const mapStateToProps = state => ({
   user: currentUser(state),
   posts: state.postsStoreV1.posts,
+  editMode: state.editMode,
 });
 
 const mapDispatchToProps = dispatch => ({ loadPosts: () => dispatch(loadPosts()) });


### PR DESCRIPTION
MELQ-146: Move edit mode state to global state
Подготовительный коммит, в нем переносим включен или нет режим редактирования в глобальное состояние, так как этот параметр используется в разных местах, хранить его в стейте компонента не получается, при навигации он сбрасывается

MELQ-146: Switch MainPage to PostCards
Основной коммит. Страница со списком трасс переделана на использование компонента PostCard. Здесь есть две проблемы:
1) Компоненты сделаны по дизайну, но дизайн рассчитан на размер экрана 1920x1080 без учета того, что у браузера есть всякие шапки наверху и скроллы сбоку или то, что, например в линуксе сбоку панель с иконками запущенных программ, поэтому на мониторе 1920x1080 при заданных размерах 3 карточки в ряд не влезает. Вопрос какие размеры делаем переменными и по какому критерию?
2) Компонент карточка поста сделана так, что в качестве текста у нее используется сокращенный post.content, но это markdown, т.е. если его предварительно обрабатывать как markdown, то туда могут попасть картинки и отформатированный текст, а если не преобразовывать markdown, то там будут строки типа ```"![img](...)"```, что тоже довольно странно. Предполагается что для текстовой части карточки будет использоваться что-то другое?