### PR TITLE
MELQ-150: Сделать страницу редактирования поста в соответствии с дизайном

### DIFF
--- a/frontend/src/v1/V1.jsx
+++ b/frontend/src/v1/V1.jsx
@@ -5,7 +5,7 @@ import { Switch, Route } from 'react-router-dom';
 import BootingScreen from './screens/BootingScreen';
 import MainPage from './screens/MainPage';
 import PostShow from './screens/PostShow';
-import PostEdit from './screens/PostEdit';
+import PostEdit from './screens/PostEdit/PostEdit';
 import { currentUser as currentUserObtainer } from './redux/user_session/utils';
 import { default as MainExamplePage } from './examples/Main';
 import examples from '@/v1/examples';

--- a/frontend/src/v1/components/CommentBlock/CommentBlockLayout.jsx
+++ b/frontend/src/v1/components/CommentBlock/CommentBlockLayout.jsx
@@ -10,7 +10,6 @@ const styles = StyleSheet.create({
   commentBlockContainer: {
     display: 'flex',
     flexDirection: 'column',
-    width: '960px',
     background: bgColor,
   },
   commentBlockContent: {

--- a/frontend/src/v1/components/Input/Input.jsx
+++ b/frontend/src/v1/components/Input/Input.jsx
@@ -17,6 +17,7 @@ const Input = ({
   disabled,
   size,
   fontSize,
+  setInputRef: setInputRefProp,
 }) => {
   const [inputRef, setInputRef] = useState(undefined);
   const [listRef, setListRef] = useState(undefined);
@@ -60,7 +61,12 @@ const Input = ({
       maxLength={maxLength}
       items={items}
       setListRef={setListRef}
-      setInputRef={setInputRef}
+      setInputRef={
+        (ref) => {
+          setInputRef(ref);
+          setInputRefProp && setInputRefProp(ref);
+        }
+      }
       onItemTriggered={onItemTriggered}
       onFocus={onFocus}
       onBlur={onBlur}
@@ -93,6 +99,7 @@ Input.propTypes = {
   disabled: PropTypes.bool,
   size: PropTypes.string,
   fontSize: PropTypes.string,
+  setInputRef: PropTypes.func,
 };
 
 export default Input;

--- a/frontend/src/v1/components/PostComments/PostComments.jsx
+++ b/frontend/src/v1/components/PostComments/PostComments.jsx
@@ -122,7 +122,6 @@ const PostComments = ({
         postSlug={slug}
         comments={comments}
         user={user}
-        width="960px"
         onChange={onChange}
         isWaiting={isWaiting}
         responseToCommentId={responseToCommentId}

--- a/frontend/src/v1/components/TextArea/TextArea.jsx
+++ b/frontend/src/v1/components/TextArea/TextArea.jsx
@@ -14,6 +14,7 @@ const TextArea = ({
   tooltipText,
   tooltipSide,
   disabled,
+  autoResize,
 }) => {
   const [textareaRef, setTextAreaRef] = useState(undefined);
 
@@ -36,6 +37,7 @@ const TextArea = ({
       onFocus={onFocus}
       setTextAreaRef={setTextAreaRef}
       disabled={disabled}
+      autoResize={autoResize}
     />
   );
 };
@@ -55,6 +57,7 @@ TextArea.propTypes = {
   tooltipText: PropTypes.string,
   tooltipSide: PropTypes.string,
   disabled: PropTypes.bool,
+  autoResize: PropTypes.bool,
 };
 
 export default TextArea;

--- a/frontend/src/v1/components/TextArea/TextAreaLayout.jsx
+++ b/frontend/src/v1/components/TextArea/TextAreaLayout.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as R from 'ramda';
+import TextareaAutosize from 'react-textarea-autosize';
 import { StyleSheet, css } from '../../aphrodite';
 import {
   mainFontColor,
@@ -31,6 +32,7 @@ const styles = StyleSheet.create({
     outline: 'none',
     paddingLeft: 20,
     paddingTop: 18,
+    paddingBottom: 18,
     border: `1px solid ${focusBorderColor}`,
     display: 'block',
     boxSizing: 'border-box',
@@ -70,6 +72,7 @@ const TextAreaLayout = ({
   onFocus,
   setTextAreaRef,
   disabled,
+  autoResize,
 }) => {
   const hasErrorOrWarnings = (touched && (error || warning)) || externalErrors;
 
@@ -88,6 +91,21 @@ const TextAreaLayout = ({
       list = R.append(externalErrors, list);
     }
     return R.flatten(list);
+  };
+
+  const props = {
+    ...input,
+    placeholder,
+    type,
+    disabled,
+    ref: setTextAreaRef,
+    className: css(
+      themeStyles.smallFont,
+      themeStyles.bordered,
+      styles.textarea,
+      errorsVisible && hasErrorOrWarnings && styles.textareaError,
+      disabled && styles.disabledTextArea,
+    ),
   };
 
   return (
@@ -136,22 +154,15 @@ const TextAreaLayout = ({
           }
         >
           <div className={css(styles.textareaContainer)}>
-            <textarea
-              {...input}
-              ref={setTextAreaRef}
-              placeholder={placeholder}
-              type={type}
-              disabled={disabled}
-              className={
-                css(
-                  themeStyles.smallFont,
-                  themeStyles.bordered,
-                  styles.textarea,
-                  errorsVisible && hasErrorOrWarnings && styles.textareaError,
-                  disabled && styles.disabledTextArea,
+            {
+              autoResize
+                ? (
+                  <TextareaAutosize {...props} />
                 )
-              }
-            />
+                : (
+                  <textarea {...props} />
+                )
+            }
             {
               maxLength && (
                 <span
@@ -191,6 +202,7 @@ TextAreaLayout.propTypes = {
   onFocus: PropTypes.func,
   setTextAreaRef: PropTypes.func,
   disabled: PropTypes.bool,
+  autoResize: PropTypes.bool,
 };
 
 export default TextAreaLayout;

--- a/frontend/src/v1/components/icon_buttons/CopyLinkButton/CopyLinkButton.jsx
+++ b/frontend/src/v1/components/icon_buttons/CopyLinkButton/CopyLinkButton.jsx
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import CopyLinkButtonLayout from './CopyLinkButtonLayout';
 
 const CopyLinkButton = ({
-  onClick,
+  onTriggered,
   disabled,
   isWaiting,
   tooltipText,
   tooltipSide,
 }) => (
   <CopyLinkButtonLayout
-    onClick={onClick}
+    onTriggered={onTriggered}
     disabled={disabled}
     isWaiting={isWaiting}
     tooltipText={tooltipText}
@@ -19,7 +19,7 @@ const CopyLinkButton = ({
 );
 
 CopyLinkButton.propTypes = {
-  onClick: PropTypes.func,
+  onTriggered: PropTypes.func,
   disabled: PropTypes.bool,
   isWaiting: PropTypes.bool,
   tooltipText: PropTypes.string,

--- a/frontend/src/v1/components/icon_buttons/CopyLinkButton/CopyLinkButtonLayout.jsx
+++ b/frontend/src/v1/components/icon_buttons/CopyLinkButton/CopyLinkButtonLayout.jsx
@@ -58,7 +58,7 @@ const styles = StyleSheet.create({
 });
 
 const CopyLinkButtonLayout = ({
-  onClick,
+  onTriggered,
   disabled,
   isWaiting,
   tooltipText,
@@ -66,7 +66,7 @@ const CopyLinkButtonLayout = ({
 }) => (
   <Icon
     src={`${require('./images/copy_link.svg')}#copy_link`}
-    onClick={onClick}
+    onTriggered={onTriggered}
     disabled={disabled}
     isWaiting={isWaiting}
     iconStyle={styles.copyLinkIcon}
@@ -80,7 +80,7 @@ const CopyLinkButtonLayout = ({
 );
 
 CopyLinkButtonLayout.propTypes = {
-  onClick: PropTypes.func,
+  onTriggered: PropTypes.func,
   disabled: PropTypes.bool,
   isWaiting: PropTypes.bool,
   tooltipText: PropTypes.string,

--- a/frontend/src/v1/layouts/CardLayout.jsx
+++ b/frontend/src/v1/layouts/CardLayout.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { css, StyleSheet } from '../aphrodite';
+import { bgColor, mainFontColor, themeStyles } from '../theme';
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: bgColor,
+    paddingTop: '35px',
+    paddingLeft: '50px',
+    paddingRight: '50px',
+    paddingBottom: '40px',
+    height: '100%',
+    boxSizing: 'border-box',
+  },
+  title: {
+    color: mainFontColor,
+    marginBottom: '14px',
+  },
+});
+
+const CardLayout = ({ children, title }) => (
+  <div className={css(styles.container)}>
+    {
+      title && (
+        <div className={css(themeStyles.headerFont, styles.title)}>{title}</div>
+      )
+    }
+    {children}
+  </div>
+);
+
+CardLayout.propTypes = {
+  children: PropTypes.node,
+  title: PropTypes.string,
+};
+
+export default CardLayout;

--- a/frontend/src/v1/layouts/MainScreen/MainScreen.jsx
+++ b/frontend/src/v1/layouts/MainScreen/MainScreen.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { css, StyleSheet } from '../../aphrodite';
 import withModals, { ModalContainerContext } from '../../modules/modalable';
 import { closeUserSession } from '@/v1/utils/auth';
+
+import { setEditMode as setEditModeAction } from '../../redux/editMode/actions';
 
 import LogInForm from '../../forms/LogInForm/LogInForm';
 import AdminPanel from './panels/AdminPanel';
@@ -43,18 +47,13 @@ class MainScreen extends React.PureComponent {
     };
   }
 
-  constructor(props) {
-    super(props);
-    this.state = { editMode: false };
-  }
-
   renderPanel = () => {
-    const { editMode } = this.state;
-    if (this.props.user) {
+    const { editMode, user, setEditMode } = this.props;
+    if (user) {
       return (
         <AdminPanel
           editMode={editMode}
-          switchEditMode={() => this.setState({ editMode: !editMode })}
+          switchEditMode={() => setEditMode(!editMode) }
           logOut={closeUserSession}
         />
       );
@@ -63,14 +62,14 @@ class MainScreen extends React.PureComponent {
   };
 
   renderHeader = () => {
-    if (this.state.editMode) {
+    if (this.props.editMode) {
       return <EditModeHeader addNewPost={() => this.props.history.push('/new')} />;
     }
     return <DefaultHeader />;
   };
 
   render() {
-    const { children, header } = this.props;
+    const { children } = this.props;
 
     return (
       <ModalContainerContext.Consumer>
@@ -101,4 +100,18 @@ class MainScreen extends React.PureComponent {
   }
 }
 
-export default withRouter(withModals(MainScreen));
+MainScreen.propTypes = {
+  editMode: PropTypes.bool,
+  setEditMode: PropTypes.func,
+  children: PropTypes.node,
+  history: PropTypes.object,
+  user: PropTypes.object,
+};
+
+const mapStateToProps = state => ({ editMode: state.editMode });
+
+const mapDispatchToProps = dispatch => (
+  { setEditMode: editMode => dispatch(setEditModeAction(editMode)) }
+);
+
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(withModals(MainScreen)));

--- a/frontend/src/v1/layouts/MainScreen/headers/DefaultHeader.jsx
+++ b/frontend/src/v1/layouts/MainScreen/headers/DefaultHeader.jsx
@@ -4,8 +4,8 @@ import { css, StyleSheet } from '../../../aphrodite';
 
 import HeaderLayout from './HeaderLayout';
 import Link from '../../../components/Link/Link';
-import Search from "../../../components/Search/Search";
-import LanguageSelect from "../../../components/LanguageSelect/LanguageSelect";
+import Search from '../../../components/Search/Search';
+import LanguageSelect from '../../../components/LanguageSelect/LanguageSelect';
 
 const styles = StyleSheet.create({
   leftBlock: {
@@ -14,6 +14,7 @@ const styles = StyleSheet.create({
   },
   blogLinkWrapper: { marginRight: 45 },
   aboutBlogLinkWrapper: { marginRight: 48 },
+  languageSelectWrapper: { textAlign: 'right' },
 });
 
 const DefaultHeader = () => (
@@ -29,7 +30,7 @@ const DefaultHeader = () => (
         <Search onChange={() => {}} variants={[]} />
       </div>
     </div>
-    <div>
+    <div className={css(styles.languageSelectWrapper)}>
       <LanguageSelect onChange={() => {}} languageId="ru" />
     </div>
   </HeaderLayout>

--- a/frontend/src/v1/layouts/MainScreen/headers/EditModeHeader.jsx
+++ b/frontend/src/v1/layouts/MainScreen/headers/EditModeHeader.jsx
@@ -1,21 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { css, StyleSheet } from '../../../aphrodite';
 
 import HeaderLayout from './HeaderLayout';
 import Search from '../../../components/Search/Search';
 import Button from '../../../components/Button/Button';
 
-const styles = StyleSheet.create({ addPostBtn: { width: 203 } });
+const styles = StyleSheet.create({
+  searchWrapper: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});
 
 const EditModeHeader = ({ addNewPost }) => (
   <HeaderLayout>
-    <div>
+    <div className={css(styles.searchWrapper)}>
       <Search variants={[]} onChange={() => {}} />
     </div>
-    <div className={css(styles.addPostBtn)}>
-      <Button onClick={addNewPost} btnStyle="success">Добавить новый пост</Button>
-    </div>
+    <Button onClick={addNewPost} btnStyle="success">Добавить новый пост</Button>
   </HeaderLayout>
 );
 

--- a/frontend/src/v1/layouts/MainScreen/headers/HeaderLayout.jsx
+++ b/frontend/src/v1/layouts/MainScreen/headers/HeaderLayout.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import { css, StyleSheet } from '../../../aphrodite';
 import { separatorColor } from '@/v1/theme';
 
+import TwoColumnsLayout from '../../TwoColumnsLayout';
+
 const styles = StyleSheet.create({
   container: {
     height: 104,
     width: '100%',
     display: 'flex',
-    justifyContent: 'space-between',
     borderBottom: `1px solid ${separatorColor}`,
     alignItems: 'center',
   },
@@ -16,7 +17,9 @@ const styles = StyleSheet.create({
 
 const HeaderLayout = ({ children }) => (
   <div className={css(styles.container)}>
-    {children}
+    <TwoColumnsLayout>
+      {children}
+    </TwoColumnsLayout>
   </div>
 );
 

--- a/frontend/src/v1/layouts/TwoColumnsLayout.jsx
+++ b/frontend/src/v1/layouts/TwoColumnsLayout.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { css, StyleSheet } from '../aphrodite';
+
+const styles = StyleSheet.create({
+  container: {
+    display: 'grid',
+    gridTemplateColumns: '78% 22%',
+    width: '100%',
+  },
+  rightColumn: { marginLeft: 70 },
+});
+
+const TwoColumnsLayout = ({ children }) => (
+  <div className={css(styles.container)}>
+    {children[0]}
+    <div className={css(styles.rightColumn)}>
+      {children[1]}
+    </div>
+  </div>
+);
+
+TwoColumnsLayout.propTypes = { children: PropTypes.node };
+
+export default TwoColumnsLayout;

--- a/frontend/src/v1/reducers.js
+++ b/frontend/src/v1/reducers.js
@@ -5,6 +5,7 @@ import { default as postsReducerV1 } from '@/v1/redux/posts/reducer';
 import { default as commentsReducerV1 } from '@/v1/redux/comments/reducer';
 import { default as tagsReducerV1 } from '@/v1/redux/tags/reducer';
 import { default as userSessionReducerV1 } from '@/v1/redux/user_session/reducer';
+import { default as editModeReducerV1 } from '@/v1/redux/editMode/reducer';
 
 export default combineReducers({
   usersStoreV1: usersReducerV1,
@@ -13,4 +14,5 @@ export default combineReducers({
   tagsStoreV1: tagsReducerV1,
   userSessionV1: userSessionReducerV1,
   form: formReducer,
+  editMode: editModeReducerV1,
 });

--- a/frontend/src/v1/redux/editMode/actions.js
+++ b/frontend/src/v1/redux/editMode/actions.js
@@ -1,0 +1,8 @@
+import acts from './acts';
+
+export const setEditMode = editMode => ({
+  type: acts.SET_EDIT_MODE,
+  editMode,
+});
+
+export default setEditMode;

--- a/frontend/src/v1/redux/editMode/acts.js
+++ b/frontend/src/v1/redux/editMode/acts.js
@@ -1,0 +1,3 @@
+const acts = { SET_EDIT_MODE: 'SET_EDIT_MODE_V1' };
+
+export default acts;

--- a/frontend/src/v1/redux/editMode/reducer.js
+++ b/frontend/src/v1/redux/editMode/reducer.js
@@ -1,0 +1,12 @@
+import acts from './acts';
+
+const editModeReducer = (state = false, action) => {
+  switch (action.type) {
+  case acts.SET_EDIT_MODE:
+    return action.editMode;
+  default:
+    return state;
+  }
+};
+
+export default editModeReducer;

--- a/frontend/src/v1/screens/MainPage.jsx
+++ b/frontend/src/v1/screens/MainPage.jsx
@@ -1,43 +1,109 @@
 import React from 'react';
-import { withRouter, Link } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import * as R from 'ramda';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import MainScreen from '../layouts/MainScreen/MainScreen';
+
+import { css, StyleSheet } from '../aphrodite';
+
 import { currentUser } from '@/v1/redux/user_session/utils';
 import { loadPosts } from '@/v1/redux/posts/actions';
 
+import MainScreen from '../layouts/MainScreen/MainScreen';
+import PostCard from '../components/PostCard/PostCard';
+import Button from '../components/Button/Button';
+
+const mapIndexed = R.addIndex(R.map);
+
+const btns = [
+  {
+    text: 'Опубликованные',
+    style: 'info',
+  },
+  { text: 'Черновики' },
+];
+
+const styles = StyleSheet.create({
+  cardsWrapper: {
+    marginTop: -2,
+    marginLeft: -32,
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  },
+  defaultHeader: { marginTop: 12 },
+  editModeHeader: { marginTop: 30 },
+  btnsContainer: { width: 289 },
+});
 
 class MainPage extends React.PureComponent {
   componentDidMount() {
     this.props.loadPosts();
   }
 
+  onCardClick = (post, e, target) => {
+    e.stopPropagation();
+    switch (target) {
+    case 'like':
+      console.log('Click on like counter');
+      break;
+    case 'comment':
+      console.log('Redirect to comment');
+      break;
+    case 'share':
+      console.log('Share post');
+      break;
+    default:
+      this.props.history.push(`/${post.slug}`);
+    }
+  };
+
   render() {
-    const { user, posts } = this.props;
+    const { user, posts, editMode } = this.props;
 
     return (
       <MainScreen header="" user={user}>
-        {
-          R.map(
-            post => (
-              <div key={post.slug}>
-                <h2>{post.title}</h2>
-                <div>{post.updated_at}</div>
-                <div>{`Tags: ${R.join(', ', R.map(tag => tag.text, post.tags))}`}</div>
-                <div>{`Likes: ${post.num_of_likes || 0}`}</div>
-                <div>{`Reposts: ${post.num_of_reposts || 0}`}</div>
-                <div>{`Views: ${post.num_of_views || 0}`}</div>
-                <div>
-                  <Link to={`/${post.slug}`}>Open</Link>
-                  |
-                  <Link to={`/${post.slug}/edit`}>Edit</Link>
-                </div>
+        <div className={css(styles.defaultHeader, editMode && styles.editModeHeader)}>
+          {
+            editMode && (
+              <div className={css(styles.btnsContainer)}>
+                <Button
+                  onClick={() => {}}
+                  size="big"
+                  tooltipText={R.map(btn => btn.tooltipText, btns)}
+                  tooltipSide={R.map(btn => btn.tooltipSide, btns)}
+                  disabled={R.map(btn => btn.disabled, btns)}
+                  btnStyle={R.map(btn => btn.style, btns)}
+                  isWaiting={R.map(btn => btn.isWaiting, btns)}
+                >
+                  {
+                    mapIndexed(
+                      (btn, index) => (
+                        <div key={index}>{btn.text}</div>
+                      ),
+                      btns,
+                    )
+                  }
+                </Button>
               </div>
-            ),
-            R.values(posts),
-          )
-        }
+            )
+          }
+        </div>
+        <div className={css(styles.cardsWrapper)}>
+          {
+            R.map(
+              post => (
+                <PostCard
+                  post={post}
+                  onClick={(e, target) => this.onCardClick(post, e, target)}
+                  disabledCounter={false}
+                  key={post.id}
+                />
+              ),
+              R.values(posts),
+            )
+          }
+        </div>
       </MainScreen>
     );
   }
@@ -46,11 +112,15 @@ class MainPage extends React.PureComponent {
 MainPage.propTypes = {
   user: PropTypes.object,
   posts: PropTypes.object,
+  editMode: PropTypes.bool,
+  history: PropTypes.object,
+  loadPosts: PropTypes.func,
 };
 
 const mapStateToProps = state => ({
   user: currentUser(state),
   posts: state.postsStoreV1.posts,
+  editMode: state.editMode,
 });
 
 const mapDispatchToProps = dispatch => ({ loadPosts: () => dispatch(loadPosts()) });

--- a/frontend/src/v1/screens/PostEdit/AutopostInfo.jsx
+++ b/frontend/src/v1/screens/PostEdit/AutopostInfo.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import CardLayout from '../../layouts/CardLayout';
+import TextAreaWithPhotoLoader from '../../components/TextAreaWithPhotoLoader/TextAreaWithPhotoLoader';
+import InstagramIcon from '../../components/social_links/InstagramIcon/InstagramIcon';
+import VKIcon from '../../components/social_links/VKIcon/VKIcon';
+import FacebookIcon from '../../components/social_links/FacebookIcon/FacebookIcon';
+
+import { css, StyleSheet } from '../../aphrodite';
+import { mainFontColor, themeStyles } from '../../theme';
+
+const styles = StyleSheet.create({
+  title: {
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: '17px',
+  },
+  titleWithMargin: { marginTop: '24px' },
+  label: {
+    color: mainFontColor,
+    marginLeft: '7px',
+  },
+});
+
+const AutopostInfo = ({ post, onChange, onLoadPhoto, onRemovePhoto }) => (
+  <CardLayout title="Автопостинг анонсов">
+    <div className={css(styles.title)}>
+      <InstagramIcon />
+      <span className={css(themeStyles.defaultFont, styles.label)}>Instagram</span>
+    </div>
+    <TextAreaWithPhotoLoader
+      placeholder="Введите текст анонса"
+      text={post.instagram_content}
+      onChange={event => onChange('instagram_content', event.target.value)}
+      onLoadPhoto={data => onLoadPhoto('instagram', data)}
+      onRemovePhoto={index => onRemovePhoto('instagram', index)}
+    />
+    <div className={css(styles.title, styles.titleWithMargin)}>
+      <VKIcon />
+      <span className={css(themeStyles.defaultFont, styles.label)}>Instagram</span>
+    </div>
+    <TextAreaWithPhotoLoader
+      placeholder="Введите текст анонса"
+      text={post.vk_content}
+      onChange={event => onChange('vk_content', event.target.value)}
+      onLoadPhoto={data => onLoadPhoto('vk', data)}
+      onRemovePhoto={index => onRemovePhoto('vk', index)}
+    />
+    <div className={css(styles.title, styles.titleWithMargin)}>
+      <FacebookIcon />
+      <span className={css(themeStyles.defaultFont, styles.label)}>Instagram</span>
+    </div>
+    <TextAreaWithPhotoLoader
+      placeholder="Введите текст анонса"
+      text={post.facebook_content}
+      onChange={event => onChange('facebook_content', event.target.value)}
+      onLoadPhoto={data => onLoadPhoto('facebook', data)}
+      onRemovePhoto={index => onRemovePhoto('facebook', index)}
+    />
+  </CardLayout>
+);
+
+AutopostInfo.propTypes = {
+  post: PropTypes.object,
+  onChange: PropTypes.func,
+  onLoadPhoto: PropTypes.func,
+  onRemovePhoto: PropTypes.func,
+};
+
+export default AutopostInfo;

--- a/frontend/src/v1/screens/PostEdit/PostCardInfo.jsx
+++ b/frontend/src/v1/screens/PostEdit/PostCardInfo.jsx
@@ -1,0 +1,159 @@
+import React, { useState } from 'react';
+import * as R from 'ramda';
+import PropTypes from 'prop-types';
+
+import Select from '../../components/Select/Select';
+import Input from '../../components/Input/Input';
+import CardLayout from '../../layouts/CardLayout';
+import Button from '../../components/Button/Button';
+import PhotoPreview from '../../components/PhotoPreview/PhotoPreview';
+
+import { css, StyleSheet } from '../../aphrodite';
+import { cardColors, defaultColor, mainFontColor, themeStyles, focusBorderColor } from '../../theme';
+
+const styles = StyleSheet.create({
+  cardThemeWrapper: { width: '368px' },
+  cardView: { marginTop: '21px' },
+  cardViewLabel: { color: defaultColor },
+  cardViewItems: {
+    display: 'flex',
+    marginTop: '13px',
+  },
+  cardViewPhotoBtn: { width: '127px' },
+  cardViewBgBtn: {
+    width: '127px',
+    marginLeft: '13px',
+  },
+  inputWrapper: { marginTop: '21px' },
+  photoBlock: { marginTop: '30px' },
+  loadBtnWrapper: {
+    display: 'inline-block',
+    width: '133px',
+    marginLeft: '15px',
+  },
+  photoLabelText: { color: mainFontColor },
+  photosContainer: { marginTop: '12px' },
+  colorPicker: {
+    display: 'flex',
+    marginTop: '14px',
+  },
+  colorPickerItem: {
+    width: '80px',
+    height: '80px',
+    marginRight: '10px',
+    cursor: 'pointer',
+  },
+  colorItemSelected: { border: `2px solid ${focusBorderColor}` },
+});
+
+const PostCardInfo = ({ post, removeCardImage, loadCardImage }) => {
+  const [viewMode, setViewMode] = useState('photo');
+  const [selectedColor, setSelectedColor] = useState(undefined);
+  const [fileInputRef, setFileInputRef] = useState(undefined);
+
+  return (
+    <CardLayout title="Наполнение карточки поста">
+      <div className={css(styles.cardThemeWrapper)}>
+        <Select
+          input={{}}
+          items={[]}
+          placeholder="Выберите темы"
+          label="Главная тема поста"
+        />
+      </div>
+      <div className={css(styles.cardView)}>
+        <div className={css(styles.cardViewLabel, themeStyles.defaultFont)}>
+          Вид карточки
+        </div>
+        <div className={css(styles.cardViewItems)}>
+          <div className={css(styles.cardViewPhotoBtn)}>
+            <Button
+              onClick={() => setViewMode('photo')}
+              btnStyle={viewMode === 'photo' ? 'info' : null}
+            >
+              Фотография
+            </Button>
+          </div>
+          <div className={css(styles.cardViewBgBtn)}>
+            <Button
+              onClick={() => setViewMode('background')}
+              btnStyle={viewMode === 'background' ? 'info' : null}
+            >
+              Заливка
+            </Button>
+          </div>
+        </div>
+        <div>
+          {
+            viewMode === 'photo'
+              ? (
+                <div className={css(styles.photoBlock)}>
+                  <div>
+                    <span className={css(styles.photoLabelText, themeStyles.defaultFont)}>
+                      Фотографии поста (рекомендуемый размер 11111х2222)
+                    </span>
+                    <div className={css(styles.loadBtnWrapper)}>
+                      <Button onClick={() => fileInputRef.click()}>Загрузить</Button>
+                      <input
+                        ref={setFileInputRef}
+                        type="file"
+                        hidden
+                        onChange={event => loadCardImage(event.target.files[0])}
+                      />
+                    </div>
+                    {
+                      post.card_image && (
+                        <div className={css(styles.photosContainer)}>
+                          <PhotoPreview
+                            src={post.card_image}
+                            remove={() => removeCardImage()}
+                          />
+                        </div>
+                      )
+                    }
+                  </div>
+                </div>
+              )
+              : (
+                <div className={css(styles.colorPicker)}>
+                  {
+                    R.map(
+                      color => (
+                        <div
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => setSelectedColor(color)}
+                          className={
+                            css(
+                              styles.colorPickerItem,
+                              color === selectedColor && styles.colorItemSelected
+                            )
+                          }
+                          style={{ backgroundColor: color }}
+                        />
+                      ),
+                      R.values(cardColors),
+                    )
+                  }
+                </div>
+              )
+          }
+        </div>
+      </div>
+      <div className={css(styles.inputWrapper)}>
+        <Input input={{ value: post.card_title }} maxLength={56} label="Заголовок карточки" />
+      </div>
+      <div className={css(styles.inputWrapper)}>
+        <Input input={{}} maxLength={58} label="Краткое описание" />
+      </div>
+    </CardLayout>
+  );
+};
+
+PostCardInfo.propTypes = {
+  post: PropTypes.object,
+  removeCardImage: PropTypes.func,
+  loadCardImage: PropTypes.func,
+};
+
+export default PostCardInfo;

--- a/frontend/src/v1/screens/PostEdit/PostContentInfo.jsx
+++ b/frontend/src/v1/screens/PostEdit/PostContentInfo.jsx
@@ -1,0 +1,170 @@
+import React, { useState } from 'react';
+import * as R from 'ramda';
+import PropTypes from 'prop-types';
+
+import Input from '../../components/Input/Input';
+import CardLayout from '../../layouts/CardLayout';
+import Button from '../../components/Button/Button';
+import PhotoPreview from '../../components/PhotoPreview/PhotoPreview';
+import TextArea from '../../components/TextArea/TextArea';
+
+import { css, StyleSheet } from '../../aphrodite';
+import { mainFontColor, themeStyles } from '../../theme';
+
+const styles = StyleSheet.create({
+  postContentWrapper: { marginTop: '24px' },
+  photoBlock: { marginTop: '30px' },
+  loadBtnWrapper: {
+    display: 'inline-block',
+    width: '133px',
+    marginLeft: '15px',
+  },
+  photoLabelText: { color: mainFontColor },
+  photoPreviewWrapper: {
+    display: 'inline-block',
+    marginRight: '10px',
+  },
+  photosContainer: { marginTop: '12px' },
+});
+
+const PostContentInfo = ({
+  post,
+  onChangePostParams,
+  images,
+  imagesUpdatedNames,
+  removeImage,
+  checkNameUniq,
+  removeJustLoadedImage,
+  setImages,
+  setImagesUpdatedNames,
+  loadImage,
+  removedImagesIds,
+}) => {
+  const [fileInputRef, setFileInputRef] = useState(undefined);
+
+  const mapIndexed = R.addIndex(R.map);
+  const validFileNameRe = new RegExp('^[а-яА-Яa-zA-Z0-9-_.]*$');
+
+  return (
+    <CardLayout title="Наполнение поста">
+      <Input
+        input={
+          {
+            onChange: event => onChangePostParams('title', event.target.value),
+            value: post.title,
+          }
+        }
+        label="Заголовок поста*"
+        fontSize="small"
+      />
+      <div className={css(styles.postContentWrapper)}>
+        <TextArea
+          input={
+            {
+              onChange: event => onChangePostParams('content', event.target.value),
+              value: post.content,
+            }
+          }
+          label="Текстовый блок*"
+          autoResize
+        />
+      </div>
+      <div className={css(styles.photoBlock)}>
+        <div>
+          <span className={css(styles.photoLabelText, themeStyles.defaultFont)}>
+            Фотографии поста (рекомендуемый размер 11111х2222)
+          </span>
+          <div className={css(styles.loadBtnWrapper)}>
+            <Button onClick={() => fileInputRef.click()}>Загрузить</Button>
+            <input
+              ref={setFileInputRef}
+              type="file"
+              hidden
+              onChange={event => loadImage(event.target.files[0])}
+            />
+          </div>
+          <div className={css(styles.photosContainer)}>
+            {
+              R.map(
+                image => (
+                  <div key={image.id} className={css(styles.photoPreviewWrapper)}>
+                    <PhotoPreview
+                      src={image.url}
+                      remove={() => removeImage(image.id)}
+                      onTitleChange={
+                        (name) => {
+                          if (!R.test(validFileNameRe, name)) {
+                            return;
+                          }
+                          setImagesUpdatedNames({
+                            ...imagesUpdatedNames,
+                            [image.id]: name,
+                          });
+
+                          checkNameUniq(
+                            imagesUpdatedNames[image.id] || image.original_filename,
+                          );
+                        }
+                      }
+                      title={imagesUpdatedNames[image.id] || image.original_filename}
+                    />
+                  </div>
+                ),
+                R.reject(
+                  a => R.contains(a.id, removedImagesIds),
+                  post.images || [],
+                ),
+              )
+            }
+            {
+              mapIndexed(
+                (image, index) => (
+                  <div key={index} className={css(styles.photoPreviewWrapper)}>
+                    <PhotoPreview
+                      src={image.content}
+                      remove={() => removeJustLoadedImage(index)}
+                      onTitleChange={
+                        (name) => {
+                          if (!R.test(validFileNameRe, name)) {
+                            return;
+                          }
+                          setImages(
+                            [
+                              ...R.slice(0, index, images),
+                              { ...image, name },
+                              ...R.slice(index + 1, Infinity, images),
+                            ],
+                          );
+
+                          checkNameUniq(image.name);
+                        }
+                      }
+                      title={image.name}
+                    />
+                  </div>
+                ),
+                images,
+              )
+            }
+          </div>
+        </div>
+      </div>
+    </CardLayout>
+  );
+};
+
+PostContentInfo.propTypes = {
+  post: PropTypes.object,
+  onChangePostParams: PropTypes.func,
+  images: PropTypes.array,
+  imagesUpdatedNames: PropTypes.object,
+  removeImage: PropTypes.func,
+  checkNameUniq: PropTypes.func,
+  removeJustLoadedImage: PropTypes.func,
+  setImages: PropTypes.func,
+  setImagesUpdatedNames: PropTypes.func,
+  loadImage: PropTypes.func,
+  removedImagesIds: PropTypes.array,
+};
+
+export default PostContentInfo;

--- a/frontend/src/v1/screens/PostEdit/PostEdit.jsx
+++ b/frontend/src/v1/screens/PostEdit/PostEdit.jsx
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import marked from 'marked';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import MainScreen from '../layouts/MainScreen/MainScreen';
+import MainScreen from '../../layouts/MainScreen/MainScreen';
 import { loadPost, updatePost, createPost, removePost } from '@/v1/redux/posts/actions';
 import { loadTags } from '@/v1/redux/tags/actions';
 import FormField from '@/v1/components/FormField/FormField';

--- a/frontend/src/v1/screens/PostEdit/PostLinkInfo.jsx
+++ b/frontend/src/v1/screens/PostEdit/PostLinkInfo.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import Input from '../../components/Input/Input';
+import CardLayout from '../../layouts/CardLayout';
+import CopyLinkButton from '../../components/icon_buttons/CopyLinkButton/CopyLinkButton';
+
+import { css, StyleSheet } from '../../aphrodite';
+
+const styles = StyleSheet.create({
+  container: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  inputWrapper: {
+    width: '368px',
+    marginRight: '8px',
+  },
+});
+
+const PostLinkInfo = ({ link }) => {
+  const [inputRef, setInputRef] = useState(undefined);
+
+  return (
+    <CardLayout title="Ссылка на пост">
+      <div className={css(styles.container)}>
+        <div className={css(styles.inputWrapper)}>
+          <Input
+            setInputRef={setInputRef}
+            input={{ value: link }}
+            placeholder="Адрес ссылки на пост"
+          />
+        </div>
+        <span>
+          <CopyLinkButton
+            onTriggered={
+              () => {
+                inputRef.select();
+                document.execCommand('copy');
+              }
+            }
+          />
+        </span>
+      </div>
+    </CardLayout>
+  );
+};
+
+PostLinkInfo.propTypes = { link: PropTypes.string };
+
+export default PostLinkInfo;

--- a/frontend/src/v1/screens/PostEdit/SeoInfo.jsx
+++ b/frontend/src/v1/screens/PostEdit/SeoInfo.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Input from '../../components/Input/Input';
+import CardLayout from '../../layouts/CardLayout';
+
+import { css, StyleSheet } from '../../aphrodite';
+
+const styles = StyleSheet.create({ row: { marginTop: '21px' } });
+
+const SeoInfo = ({ post, onChange }) => (
+  <CardLayout title="SEO-информация">
+    <Input
+      input={{ value: post.slug, onChange: event => onChange('slug', event.target.value) }}
+      label="Slug"
+    />
+    <div className={css(styles.row)}>
+      <Input
+        input={{ value: post.seo_title, onChange: event => onChange('seo_title', event.target.value) }}
+        label="SEO-заголовок"
+      />
+    </div>
+    <div className={css(styles.row)}>
+      <Input
+        input={{ value: post.seo_kw, onChange: event => onChange('seo_kw', event.target.value) }}
+        label="SEO-ключевые слова"
+      />
+    </div>
+  </CardLayout>
+);
+
+SeoInfo.propTypes = {
+  post: PropTypes.object,
+  onChange: PropTypes.func,
+};
+
+export default SeoInfo;

--- a/frontend/src/v1/screens/PostShow.jsx
+++ b/frontend/src/v1/screens/PostShow.jsx
@@ -1,19 +1,102 @@
 import React from 'react';
-import { withRouter, Link } from 'react-router-dom';
+import dayjs from 'dayjs';
+import { withRouter } from 'react-router-dom';
 import * as R from 'ramda';
 import marked from 'marked';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import MainScreen from '../layouts/MainScreen/MainScreen';
-import { notReady, notExist } from '@/v1/utils';
 import { currentUser } from '@/v1/redux/user_session/utils';
-import { closeUserSession } from '@/v1/utils/auth';
 import { loadPost } from '@/v1/redux/posts/actions';
 import { loadComments } from '@/v1/redux/comments/actions';
-import Button from '@/v1/components/Button/Button';
 import prepareImageUrls from '@/v1/utils/prepareImageUrls';
 import PostComments from '../components/PostComments/PostComments';
+import Button from '../components/Button/Button';
+import LikeCounter from '../components/icon_counters/LikeCounter/LikeCounter';
+import CommentCounter from '../components/icon_counters/CommentCounter/CommentCounter';
+import Link from '../components/Link/Link';
+import TwoColumnsLayout from '../layouts/TwoColumnsLayout';
+import ShareCounter from '../components/icon_counters/ShareCounter/ShareCounter';
+import ViewCounter from '../components/icon_counters/ViewCounter/ViewCounter';
+import Item from '../components/Item/Item';
 
+import { StyleSheet, css } from '../aphrodite';
+
+import { bgColor, separatorColor, themeStyles, dateTopicCounterColor } from '../theme';
+
+const styles = StyleSheet.create({
+  container: { marginTop: 40 },
+  mainContentWrapper: { paddingBottom: 80 },
+  rightBlock: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  mainContent: {
+    backgroundColor: bgColor,
+    paddingLeft: 62,
+    paddingRight: 56,
+    paddingTop: 32,
+    paddingBottom: 32,
+    marginBottom: 32,
+  },
+  commentBlock: {
+    marginTop: 32,
+    backgroundColor: bgColor,
+    paddingLeft: 62,
+    paddingRight: 56,
+    paddingTop: 32,
+    paddingBottom: 32,
+  },
+  deleteBtnWrapper: {
+    textAlign: 'center',
+    marginTop: 24,
+    marginBottom: 24,
+  },
+  likeCounterContainer: {
+    width: 72,
+    paddingTop: 21,
+    paddingRight: 10,
+    paddingLeft: 17,
+    paddingBottom: 21,
+    border: `1px solid ${separatorColor}`,
+  },
+  commentCounterContainer: {
+    width: 72,
+    paddingTop: 21,
+    paddingRight: 10,
+    paddingLeft: 17,
+    paddingBottom: 19,
+    border: `1px solid ${separatorColor}`,
+    borderTopWidth: 0,
+  },
+  deleteBtnLinkText: {
+    marginLeft: 7,
+    marginTop: 1,
+  },
+  deleteBtnInnerContainer: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  editBtnText: { marginLeft: 7 },
+  topInfoBlock: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  shareCounterWrapper: { marginLeft: 31 },
+  viewCounterWrapper: { marginLeft: 32 },
+  dateText: { color: dateTopicCounterColor },
+  postTitle: {
+    marginTop: 32,
+    marginBottom: 14,
+  },
+  topicBlock: {
+    borderTop: `1px solid ${separatorColor}`,
+    paddingTop: 32,
+    display: 'flex',
+  },
+  itemWrapper: { marginRight: 32 },
+});
 
 class PostShow extends React.PureComponent {
   constructor(props) {
@@ -41,44 +124,102 @@ class PostShow extends React.PureComponent {
   };
 
   render() {
-    const { user, history, posts } = this.props;
+    const { user, posts, history, editMode } = this.props;
 
     const post = posts[this.props.match.params.slug];
 
     return (
-      <MainScreen header="">
-        {
-          (!notReady(user) && notExist(user))
-            ? (
-              <Button onClick={() => history.push('#signin')}>Войти</Button>
-            )
-            : (
-              <Button onClick={closeUserSession}>Выйти</Button>
-            )
-        }
-        {
-          post && (
-            <div key={post.id}>
-              <h2>{post.title}</h2>
-              <div>{post.updated_at}</div>
-              <div
-                dangerouslySetInnerHTML={
-                  { __html: marked(this.prepareImageUrls(post.content || '')) }
+      <MainScreen header="" user={user}>
+        <div className={css(styles.container)}>
+          <TwoColumnsLayout>
+            <div className={css(styles.mainContentWrapper)}>
+              <div className={css(styles.mainContent)}>
+                {
+                  post && (
+                    <div key={post.id}>
+                      <div className={css(styles.topInfoBlock)}>
+                        <span className={css(themeStyles.defaultFont, styles.dateText)}>
+                          {dayjs(post.created_at).format('DD.MM.YYYY')}
+                        </span>
+                        <div className={css(styles.shareCounterWrapper)}>
+                          <ShareCounter value={post.num_of_reposts} onClick={() => {}} />
+                        </div>
+                        <div className={css(styles.viewCounterWrapper)}>
+                          <ViewCounter value={post.num_of_views} />
+                        </div>
+                      </div>
+                      <div className={css(themeStyles.largeHeaderFont, styles.postTitle)}>
+                        {post.title}
+                      </div>
+                      <div
+                        dangerouslySetInnerHTML={
+                          { __html: marked(this.prepareImageUrls(post.content || '')) }
+                        }
+                      />
+                    </div>
+                  )
                 }
-              />
-              <div>{`Tags: ${R.join(', ', R.map(tag => tag.text, post.tags))}`}</div>
-              <div>{`Likes: ${post.num_of_likes || 0}`}</div>
-              <div>{`Reposts: ${post.num_of_reposts || 0}`}</div>
-              <div>{`Views: ${post.num_of_views || 0}`}</div>
-              <PostComments />
-              <div>
-                <Link to="/">Back</Link>
-                |
-                <Link to={`/${post.slug}/edit`}>Edit</Link>
+                <div className={css(styles.topicBlock)}>
+                  {
+                    R.map(
+                      tag => (
+                        <div className={css(styles.itemWrapper)}>
+                          <Item
+                            onTriggered={() => {}}
+                            size="small"
+                            iconSrc={require('../examples/images/demoItemIcon.png')}
+                            text={tag.text}
+                          />
+                        </div>
+                      ),
+                      post?.tags || [],
+                    )
+                  }
+                </div>
               </div>
+              <PostComments />
             </div>
-          )
-        }
+            <div className={css(styles.rightBlock)}>
+              {
+                editMode && (
+                  <div className={css(styles.btnContainer)}>
+                    <Button onClick={() => history.push(`/${post.slug}/edit`)}>
+                      <div>
+                        <svg width={16} height={16}>
+                          <use
+                            xlinkHref={`${require('../components/Button/images/edit.svg')}#edit`}
+                          />
+                        </svg>
+                        <span className={css(styles.editBtnText)}>Редактировать</span>
+                      </div>
+                    </Button>
+                    <div className={css(styles.deleteBtnWrapper)}>
+                      <Link onTriggered={() => {}}>
+                        <div className={css(styles.deleteBtnInnerContainer)}>
+                          <svg width={16} height={16}>
+                            <use xlinkHref={`${require('../components/Link/images/trash.svg')}#trash`} />
+                          </svg>
+                          <span className={css(styles.deleteBtnLinkText)}>Удалить</span>
+                        </div>
+                      </Link>
+                    </div>
+                  </div>
+                )
+              }
+              <div className={css(styles.likeCounterContainer)}>
+                <LikeCounter onClick={() => {}} value={post?.num_of_likes} />
+              </div>
+              <div className={css(styles.commentCounterContainer)}>
+                <CommentCounter onClick={() => {}} value={post?.num_of_comments} />
+              </div>
+              {
+                !editMode && (
+                  <div />
+                )
+              }
+            </div>
+          </TwoColumnsLayout>
+        </div>
       </MainScreen>
     );
   }
@@ -91,11 +232,13 @@ PostShow.propTypes = {
   match: PropTypes.object,
   history: PropTypes.object,
   loadComments: PropTypes.func,
+  editMode: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({
   user: currentUser(state),
   posts: state.postsStoreV1.posts,
+  editMode: state.editMode,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/src/v1/theme.js
+++ b/frontend/src/v1/theme.js
@@ -51,6 +51,12 @@ export const themeStyles = StyleSheet.create({
     fontSize: '18px',
     lineHeight: '21px',
   },
+  largeHeaderFont: {
+    fontFamily: 'GilroyRegular',
+    fontSize: '35px',
+    lineHeight: '42px',
+    fontWeight: 'bold',
+  },
   headerFont: {
     fontFamily: 'GilroyRegular',
     fontSize: '22px',


### PR DESCRIPTION
Подготовительные коммиты:
MELQ-150: Add set ref prop support for Input component
Добавляем возможность получить снаружи референс input-а
 
MELQ-150: Add autosize prop support for TextArea component
Добавляем возможность установить в пропсах autosize=true, при этом textarea будет увеличиваться по вертикали по мере набора текста, вместо того, чтобы появлялся скролл
 
MELQ-150: Fix CopyLinkButton trigger name
В этом коммите фиксится баг, вместо onClick должно быть onTriggered, как в других местах
 
MELQ-150: Move PostEdit to the separate directory
Переносим PostEdit в отдельную папку, чтобы вместе с ним сложить компоненты, которые нужны для его реализации, но больше нигде не используются

Основные коммиты:
MELQ-150: Introduce CardLayout
Добавляем layout такого вида:
![image](https://user-images.githubusercontent.com/34437046/99664280-ffbdc100-2a78-11eb-9b99-0ea34a837507.png)
Он включает в себя белый фон, отступы и заголовок, который optional, наполнение передается через children. Такой вид используется много где, поэтому логичнее вынести его в отдельный layout

MELQ-150: Introduce PostContentInfo
Добавляем компонент:
![image](https://user-images.githubusercontent.com/34437046/99664515-55926900-2a79-11eb-902f-b03cb07ec098.png)

MELQ-150: Introduce PostCardInfo
Добавляем компонент:
![image](https://user-images.githubusercontent.com/34437046/99664575-6e028380-2a79-11eb-91f6-368a4c9531d1.png)
Это пока заготовка, так как бекенда под это еще нет, он будет отдельным тикетом
 
MELQ-150: Introduce PostLinkInfo
Добавляем компонент:
![image](https://user-images.githubusercontent.com/34437046/99664658-938f8d00-2a79-11eb-9b6a-e10d0299369f.png)
 
MELQ-150: Introduce AutopostInfo
Добавляем компонент:
![image](https://user-images.githubusercontent.com/34437046/99664704-a5713000-2a79-11eb-9dba-3271482e8cf6.png)
Это тоже пока просто заготовка, так как бекендной части под это пока нет
 
MELQ-150: Introduce SeoInfo
Добавляем компонент:
![image](https://user-images.githubusercontent.com/34437046/99664775-c20d6800-2a79-11eb-8486-a0f856748621.png)
 
MELQ-150: Exchange post edit to fit design
Переделка редактирования поста на новый дизайн. Часть полей и кнопок пока сделано как заготовки, потому что либо нет бекенда, либо не до конца понятно какая реакция на кнопки должна быть.
Например пока нет реакции на кнопку "Предпросмотр", по идее при нажатии на нее надо показать обработанный markdown, но вопрос в каком виде и что должно возвращать из этого предпросмотра