### PR TITLE
MELQ-156: Переделать темы на использование сущности tags

### DIFF
--- a/frontend/src/v1/components/Theme/Theme.jsx
+++ b/frontend/src/v1/components/Theme/Theme.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ThemeLayout from './ThemeLayout';
+
+const Theme = ({ size, theme, onTriggered }) => (
+  <ThemeLayout size={size} theme={theme} onTriggered={onTriggered} />
+);
+
+Theme.propTypes = {
+  size: PropTypes.string,
+  theme: PropTypes.object,
+  onTriggered: PropTypes.func,
+};
+
+export default Theme;

--- a/frontend/src/v1/components/Theme/ThemeLayout.jsx
+++ b/frontend/src/v1/components/Theme/ThemeLayout.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Item from '../Item/Item';
+
+const ThemeLayout = ({ size, theme, onTriggered }) => (
+  <Item
+    size={size}
+    text={theme.text}
+    textMargin={size === 'small' ? '7px' : '14px'}
+    onTriggered={onTriggered}
+    focusable
+    iconSrc={require('../../examples/images/demoItemIcon.png')}
+  />
+);
+
+ThemeLayout.propTypes = {
+  onTriggered: PropTypes.func,
+  size: PropTypes.string,
+  theme: PropTypes.object,
+};
+
+export default ThemeLayout;

--- a/frontend/src/v1/components/ThemeSettings/ThemeSettings.jsx
+++ b/frontend/src/v1/components/ThemeSettings/ThemeSettings.jsx
@@ -1,40 +1,44 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import * as R from 'ramda';
+
+import { loadTags as loadTagsAction } from '@/v1/redux/tags/actions';
 
 import ThemeSettingsLayout from './ThemeSettingsLayout';
 
-const itemsWithIcons = R.map(
-  e => (
-    {
-      id: e,
-      props: {
-        text: `Тема ${e}`,
-        iconSrc: require('./assets/demoItemIcon.png'),
-        tooltipText: `Показать посты по теме ${e}`,
-      },
-    }
-  ),
-  Array.from(Array(20).keys()),
-);
-
 const DEFAULT_DISPLAYED_LENGTH = 7;
 
-const ThemeSettings = () => {
-  const [items] = useState(itemsWithIcons);
+const ThemeSettings = ({ themes, loadTags }) => {
   const [showMoreBtnVisible, setShowMoreBtnVisible] = useState(
-    itemsWithIcons.length > DEFAULT_DISPLAYED_LENGTH,
+    themes.length > DEFAULT_DISPLAYED_LENGTH,
   );
+
+  useEffect(() => setShowMoreBtnVisible(themes.length > DEFAULT_DISPLAYED_LENGTH), [themes]);
+
+  useEffect(loadTags, []);
 
   return (
     <ThemeSettingsLayout
-      items={
-        showMoreBtnVisible ? R.slice(0, DEFAULT_DISPLAYED_LENGTH, items) : items
+      themes={
+        showMoreBtnVisible ? R.slice(0, DEFAULT_DISPLAYED_LENGTH, themes) : themes
       }
       onItemTriggered={() => {}}
       onShowMore={() => setShowMoreBtnVisible(false)}
-      showMoreCount={showMoreBtnVisible ? items.length - DEFAULT_DISPLAYED_LENGTH : 0}
+      showMoreCount={showMoreBtnVisible ? themes.length - DEFAULT_DISPLAYED_LENGTH : 0}
     />
   );
 };
 
-export default ThemeSettings;
+ThemeSettings.propTypes = {
+  themes: PropTypes.array,
+  loadTags: PropTypes.func,
+};
+
+ThemeSettings.defaultProps = { themes: [] };
+
+const mapStateToProps = state => ({ themes: R.values(state.tagsStoreV1.tags) });
+
+const mapDispatchToProps = dispatch => ({ loadTags: () => dispatch(loadTagsAction()) });
+
+export default connect(mapStateToProps, mapDispatchToProps)(ThemeSettings);

--- a/frontend/src/v1/components/ThemeSettings/ThemeSettingsLayout.jsx
+++ b/frontend/src/v1/components/ThemeSettings/ThemeSettingsLayout.jsx
@@ -6,7 +6,7 @@ import { StyleSheet, css } from '../../aphrodite';
 
 import Icon from '../Icon/Icon';
 import Link from '../Link/Link';
-import Item from '../Item/Item';
+import Theme from '../Theme/Theme';
 
 import { themeStyles } from '../../theme';
 
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
   itemWrapper: { marginBottom: 16 },
 });
 
-const ThemeSettingsLayout = ({ items, onItemTriggered, showMoreCount, onShowMore }) => (
+const ThemeSettingsLayout = ({ themes, onItemTriggered, showMoreCount, onShowMore }) => (
   <div className={css(styles.container)}>
     <div className={css(styles.header)}>
       <span className={css(themeStyles.headerFont)}>Настроить ленту по темам</span>
@@ -42,12 +42,12 @@ const ThemeSettingsLayout = ({ items, onItemTriggered, showMoreCount, onShowMore
     <div>
       {
         R.map(
-          item => (
-            <div className={css(styles.itemWrapper)} key={item.id}>
-              <Item {...{ onTriggered: () => onItemTriggered(item.id), ...item.props }} />
+          theme => (
+            <div className={css(styles.itemWrapper)} key={theme.id}>
+              <Theme theme={theme} onTriggered={() => onItemTriggered(theme.id)} />
             </div>
           ),
-          items,
+          themes,
         )
       }
     </div>
@@ -60,7 +60,7 @@ const ThemeSettingsLayout = ({ items, onItemTriggered, showMoreCount, onShowMore
 );
 
 ThemeSettingsLayout.propTypes = {
-  items: PropTypes.array,
+  themes: PropTypes.array,
   onItemTriggered: PropTypes.func,
   showMoreCount: PropTypes.number,
   onShowMore: PropTypes.func,

--- a/frontend/src/v1/examples/ThemeExample.js
+++ b/frontend/src/v1/examples/ThemeExample.js
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import Theme from '@/v1/components/Theme/Theme';
+
+const demoTheme = { id: 1, text: 'Тема1' };
+
+const ThemeExample = () => {
+  const [size, setSize] = useState(null);
+
+  const onTriggered = () => {
+    console.log('triggered');
+  };
+
+  return (
+    <>
+      <div>
+        Размер:
+        <input
+          type="radio"
+          id="small"
+          name="size"
+          value="small"
+          checked={size === 'small'}
+          onClick={() => setSize('small')}
+        />
+        <span>Small</span>
+        <input
+          type="radio"
+          id="default"
+          name="size"
+          value="default"
+          checked={size === null}
+          onClick={() => setSize(null)}
+        />
+        <span>Default</span>
+      </div>
+      <Theme onTriggered={onTriggered} size={size} theme={demoTheme} />
+    </>
+  );
+};
+
+export default ThemeExample;

--- a/frontend/src/v1/examples/index.js
+++ b/frontend/src/v1/examples/index.js
@@ -22,6 +22,7 @@ import TextAreaWithPhotoLoaderExample from './TextAreaWithPhotoLoaderExample';
 import ErrorExample from './ErrorExample';
 import SelectExample from './SelectExample';
 import SearchExample from './SearchExample';
+import ThemeExample from './ThemeExample';
 
 const examples = {
   icon: IconExample,
@@ -48,6 +49,7 @@ const examples = {
   select: SelectExample,
   search: SearchExample,
   log_in_form: LogInFormExample,
+  theme: ThemeExample,
 };
 
 export default examples;

--- a/frontend/src/v1/screens/PostEdit/PostEdit.jsx
+++ b/frontend/src/v1/screens/PostEdit/PostEdit.jsx
@@ -19,7 +19,7 @@ import PostContentInfo from './PostContentInfo';
 import PostLinkInfo from './PostLinkInfo';
 import AutopostInfo from './AutopostInfo';
 import SeoInfo from './SeoInfo';
-import Item from '../../components/Item/Item';
+import Theme from '../../components/Theme/Theme';
 
 const styles = StyleSheet.create({
   container: { marginTop: '40px' },
@@ -305,10 +305,9 @@ class PostEdit extends React.PureComponent {
     R.map(
       tag => ({
         id: tag.id,
-        component: Item,
+        component: Theme,
         componentProps: {
-          text: tag.text,
-          iconSrc: require('../../examples/images/demoItemIcon.png'),
+          theme: tag,
           size: 'small',
         },
       }),

--- a/frontend/src/v1/screens/PostShow.jsx
+++ b/frontend/src/v1/screens/PostShow.jsx
@@ -18,7 +18,7 @@ import Link from '../components/Link/Link';
 import TwoColumnsLayout from '../layouts/TwoColumnsLayout';
 import ShareCounter from '../components/icon_counters/ShareCounter/ShareCounter';
 import ViewCounter from '../components/icon_counters/ViewCounter/ViewCounter';
-import Item from '../components/Item/Item';
+import Theme from '../components/Theme/Theme';
 
 import { StyleSheet, css } from '../aphrodite';
 
@@ -164,11 +164,10 @@ class PostShow extends React.PureComponent {
                     R.map(
                       tag => (
                         <div className={css(styles.itemWrapper)}>
-                          <Item
+                          <Theme
                             onTriggered={() => {}}
                             size="small"
-                            iconSrc={require('../examples/images/demoItemIcon.png')}
-                            text={tag.text}
+                            theme={tag}
                           />
                         </div>
                       ),

--- a/frontend/src/v1/screens/ThemesIndex.jsx
+++ b/frontend/src/v1/screens/ThemesIndex.jsx
@@ -13,9 +13,9 @@ import withModals from '../modules/modalable';
 
 import MainScreen from '../layouts/MainScreen/MainScreen';
 import Link from '../components/Link/Link';
-import Item from '../components/Item/Item';
 import CheckBox from '../components/CheckBox/CheckBox';
 import TagNewForm from '../forms/TagNewForm';
+import Theme from '../components/Theme/Theme';
 
 import { bgColor } from '../theme';
 
@@ -163,7 +163,7 @@ class ThemesIndex extends React.PureComponent {
                       checked={R.contains(tag.id, selectedTagsIds)}
                     />
                   </div>
-                  <Item text={tag.text} iconSrc={require('../examples/images/demoItemIcon.png')} />
+                  <Theme theme={tag} />
                 </div>
               ),
               tags,


### PR DESCRIPTION
MELQ-156: Introduce Theme component
Создание компонента:
![image](https://user-images.githubusercontent.com/34437046/99795613-1b8a9b00-2b3d-11eb-93f0-3f3dddb45951.png)
Это по сути компонент Item, у когорого в качестве текста отображается текст тега, а картинка пока захардкожена. Так будет проще потом переделать, когда определимся, что за картинку здесь отображать - надо будет только внести изменения в этот компонент.

MELQ-156: Switch tags display to theme component
Перевод того, что отображало темы на компонент Theme

MELQ-156: Switch ThemeSettings to display tags from backend
![image](https://user-images.githubusercontent.com/34437046/99795936-aff4fd80-2b3d-11eb-9912-d2ee5b63c0c0.png)
Переделка этого компонента на то, чтобы он отображал список тем на основе тегов взятых из бекенда, пока отображаются просто все теги, настройки списка еще не сделано. До этого здесь был просто захардкоженный список тем