### PR TITLE
MELQ-169: Introduce SetUpThemesForm

### DIFF
--- a/frontend/src/v1/components/ThemeSettings/ThemeSettings.jsx
+++ b/frontend/src/v1/components/ThemeSettings/ThemeSettings.jsx
@@ -9,7 +9,7 @@ import ThemeSettingsLayout from './ThemeSettingsLayout';
 
 const DEFAULT_DISPLAYED_LENGTH = 7;
 
-const ThemeSettings = ({ themes, loadTags }) => {
+const ThemeSettings = ({ themes, loadTags, setUpThemes }) => {
   const [showMoreBtnVisible, setShowMoreBtnVisible] = useState(
     themes.length > DEFAULT_DISPLAYED_LENGTH,
   );
@@ -24,6 +24,7 @@ const ThemeSettings = ({ themes, loadTags }) => {
         showMoreBtnVisible ? R.slice(0, DEFAULT_DISPLAYED_LENGTH, themes) : themes
       }
       onItemTriggered={() => {}}
+      setUpThemes={setUpThemes}
       onShowMore={() => setShowMoreBtnVisible(false)}
       showMoreCount={showMoreBtnVisible ? themes.length - DEFAULT_DISPLAYED_LENGTH : 0}
     />
@@ -33,11 +34,19 @@ const ThemeSettings = ({ themes, loadTags }) => {
 ThemeSettings.propTypes = {
   themes: PropTypes.array,
   loadTags: PropTypes.func,
+  setUpThemes: PropTypes.func,
 };
 
 ThemeSettings.defaultProps = { themes: [] };
 
-const mapStateToProps = state => ({ themes: R.values(state.tagsStoreV1.tags) });
+const mapStateToProps = state => ({
+  themes: (
+    R.reject(
+      theme => R.contains(theme.id, state.unselectedThemesIds),
+      R.values(state.tagsStoreV1.tags),
+    )
+  ),
+});
 
 const mapDispatchToProps = dispatch => ({ loadTags: () => dispatch(loadTagsAction()) });
 

--- a/frontend/src/v1/components/ThemeSettings/ThemeSettingsLayout.jsx
+++ b/frontend/src/v1/components/ThemeSettings/ThemeSettingsLayout.jsx
@@ -25,14 +25,20 @@ const styles = StyleSheet.create({
   itemWrapper: { marginBottom: 16 },
 });
 
-const ThemeSettingsLayout = ({ themes, onItemTriggered, showMoreCount, onShowMore }) => (
+const ThemeSettingsLayout = ({
+  themes,
+  onItemTriggered,
+  showMoreCount,
+  onShowMore,
+  setUpThemes,
+}) => (
   <div className={css(styles.container)}>
     <div className={css(styles.header)}>
       <span className={css(themeStyles.headerFont)}>Настроить ленту по темам</span>
       <div className={css(styles.settingsBtnWrapper)}>
         <Icon
           src={`${require('./assets/settings.svg')}#settings`}
-          onTriggered={() => console.log('Настроить темы')}
+          onTriggered={setUpThemes}
           width={24}
           height={24}
           tooltipText="Настроить темы"
@@ -64,6 +70,7 @@ ThemeSettingsLayout.propTypes = {
   onItemTriggered: PropTypes.func,
   showMoreCount: PropTypes.number,
   onShowMore: PropTypes.func,
+  setUpThemes: PropTypes.func,
 };
 
 export default ThemeSettingsLayout;

--- a/frontend/src/v1/forms/SetUpThemesForm.jsx
+++ b/frontend/src/v1/forms/SetUpThemesForm.jsx
@@ -1,0 +1,128 @@
+import React, { useContext, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import * as R from 'ramda';
+import { withRouter } from 'react-router-dom';
+
+import Modal from '../layouts/Modal';
+import Button from '../components/Button/Button';
+import CheckBox from '../components/CheckBox/CheckBox';
+import Theme from '../components/Theme/Theme';
+
+import { ModalContext } from '../modules/modalable';
+import { css, StyleSheet } from '../aphrodite';
+import { themeStyles, mainFontColor, cardColors } from '../theme';
+
+const styles = StyleSheet.create({
+  container: { width: '336px' },
+  header: { color: mainFontColor },
+  btnContainer: {
+    display: 'flex',
+    marginTop: '24px',
+  },
+  selectAllBtnWrapper: { width: '147px' },
+  unselectAllBtnWrapper: {
+    width: '147px',
+    marginLeft: '8px',
+  },
+  themeItemWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    marginTop: '16px',
+  },
+  themeWrapper: { marginLeft: '16px' },
+  saveBtnWrapper: { width: '149px' },
+  footer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    backgroundColor: cardColors[0],
+    paddingTop: '8px',
+    paddingBottom: '8px',
+    paddingRight: '23px',
+  },
+});
+
+const SetUpThemesForm = ({ save, themes, defaultUnselectedIds }) => {
+  const { closeModal } = useContext(ModalContext);
+  const [unselectedIds, setUnselectedIds] = useState(defaultUnselectedIds || []);
+
+  useEffect(() => setUnselectedIds(defaultUnselectedIds), [defaultUnselectedIds]);
+
+  const selectAll = () => {
+    setUnselectedIds([]);
+  };
+
+  const unselectAll = () => {
+    setUnselectedIds(R.map(theme => theme.id, themes));
+  };
+
+  const onItemClick = (themeId) => {
+    if (R.contains(themeId, unselectedIds)) {
+      setUnselectedIds(R.reject(id => id === themeId, unselectedIds));
+    } else {
+      setUnselectedIds([...unselectedIds, themeId]);
+    }
+  };
+
+  return (
+    <Modal
+      maxHeight="690px"
+      unscrollableFooter={
+        <div className={css(styles.footer)}>
+          <div className={css(styles.saveBtnWrapper)}>
+            <Button
+              onClick={
+                () => {
+                  save(unselectedIds);
+                  closeModal();
+                }
+              }
+              btnStyle="info"
+            >
+              Показать
+            </Button>
+          </div>
+        </div>
+      }
+    >
+      <div className={css(styles.container)}>
+        <div className={css(themeStyles.headerFont, styles.header)}>
+          Выберите темы для статей
+        </div>
+        <div className={css(styles.btnContainer)}>
+          <div className={css(styles.selectAllBtnWrapper)}>
+            <Button onClick={selectAll}>Выбрать все</Button>
+          </div>
+          <div className={css(styles.unselectAllBtnWrapper)}>
+            <Button onClick={unselectAll}>Исключить все</Button>
+          </div>
+        </div>
+        <div>
+          {
+            R.map(
+              theme => (
+                <div className={css(styles.themeItemWrapper)}>
+                  <CheckBox
+                    onClick={() => onItemClick(theme.id)}
+                    checked={!R.contains(theme.id, unselectedIds)}
+                  />
+                  <div className={css(styles.themeWrapper)}>
+                    <Theme theme={theme} />
+                  </div>
+                </div>
+              ),
+              themes,
+            )
+          }
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+SetUpThemesForm.propTypes = {
+  save: PropTypes.func,
+  themes: PropTypes.array,
+  defaultUnselectedIds: PropTypes.array,
+};
+
+export default withRouter(SetUpThemesForm);

--- a/frontend/src/v1/layouts/MainScreen/MainScreen.jsx
+++ b/frontend/src/v1/layouts/MainScreen/MainScreen.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import * as R from 'ramda';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { css, StyleSheet } from '../../aphrodite';
@@ -9,12 +10,14 @@ import { closeUserSession } from '@/v1/utils/auth';
 
 import { setEditMode as setEditModeAction } from '../../redux/editMode/actions';
 import { loadSettings } from '../../redux/settings/actions';
+import setUnselectedThemesIds from '../../redux/unselectedThemes/actions';
 
 import LogInForm from '../../forms/LogInForm/LogInForm';
 import AdminPanel from './panels/AdminPanel';
 import UserPanel from './panels/UserPanel';
 import EditModeHeader from './headers/EditModeHeader';
 import DefaultHeader from './headers/DefaultHeader';
+import SetUpThemesForm from '../../forms/SetUpThemesForm';
 
 import './scroll_workaround.css';
 
@@ -46,6 +49,16 @@ class MainScreen extends React.PureComponent {
         hashRoute: true,
         body: <LogInForm />,
       },
+      setup_themes: {
+        hashRoute: true,
+        body: (
+          <SetUpThemesForm
+            themes={this.props.tags}
+            defaultUnselectedIds={this.props.unselectedThemesIds}
+            save={this.props.setUnselectedThemesIds}
+          />
+        ),
+      },
     };
   }
 
@@ -61,6 +74,7 @@ class MainScreen extends React.PureComponent {
           editMode={editMode}
           switchEditMode={() => setEditMode(!editMode) }
           logOut={closeUserSession}
+          setUpThemes={() => this.props.history.push('#setup_themes')}
           openPrivacyPolicy={
             () => this.props.history.push(`/${this.props.settings.privacy_policy_slug}`)
           }
@@ -70,6 +84,7 @@ class MainScreen extends React.PureComponent {
     return (
       <UserPanel
         signIn={() => this.props.history.push('#signin')}
+        setUpThemes={() => this.props.history.push('#setup_themes')}
         openPrivacyPolicy={
           () => this.props.history.push(`/${this.props.settings.privacy_policy_slug}`)
         }
@@ -136,16 +151,22 @@ MainScreen.propTypes = {
   user: PropTypes.object,
   settings: PropTypes.object,
   loadSettings: PropTypes.func,
+  tags: PropTypes.array,
+  setUnselectedThemesIds: PropTypes.func,
+  unselectedThemesIds: PropTypes.array,
 };
 
 const mapStateToProps = state => ({
   editMode: state.editMode,
   settings: state.settingsStoreV1.settings[1],
+  tags: R.values(state.tagsStoreV1.tags),
+  unselectedThemesIds: state.unselectedThemesIds,
 });
 
 const mapDispatchToProps = dispatch => ({
   setEditMode: editMode => dispatch(setEditModeAction(editMode)),
   loadSettings: () => dispatch(loadSettings()),
+  setUnselectedThemesIds: themesIds => dispatch(setUnselectedThemesIds(themesIds)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(withModals(MainScreen)));

--- a/frontend/src/v1/layouts/MainScreen/panels/AdminPanel.jsx
+++ b/frontend/src/v1/layouts/MainScreen/panels/AdminPanel.jsx
@@ -74,7 +74,13 @@ const styles = StyleSheet.create({
   logOutBtnWrapper: { width: 25 },
 });
 
-const AdminPanel = ({ editMode, switchEditMode, logOut, openPrivacyPolicy }) => (
+const AdminPanel = ({
+  editMode,
+  switchEditMode,
+  logOut,
+  openPrivacyPolicy,
+  setUpThemes,
+}) => (
   <PanelLayout>
     <div className={css(styles.container)}>
       <div className={css(styles.editSwitchWrapper)}>
@@ -111,7 +117,7 @@ const AdminPanel = ({ editMode, switchEditMode, logOut, openPrivacyPolicy }) => 
           : (
             <div className={css(styles.content)}>
               <div className={css(styles.themeSettingsWrapper)}>
-                <ThemeSettings />
+                <ThemeSettings setUpThemes={setUpThemes} />
               </div>
               <div className={css(styles.defaultFooter)}>
                 <Link onTriggered={openPrivacyPolicy} linkStyle="dark" size="big">
@@ -133,6 +139,7 @@ AdminPanel.propTypes = {
   switchEditMode: PropTypes.func,
   logOut: PropTypes.func,
   openPrivacyPolicy: PropTypes.func,
+  setUpThemes: PropTypes.func,
 };
 
 export default AdminPanel;

--- a/frontend/src/v1/layouts/MainScreen/panels/UserPanel.jsx
+++ b/frontend/src/v1/layouts/MainScreen/panels/UserPanel.jsx
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const UserPanel = ({ signIn, openPrivacyPolicy }) => (
+const UserPanel = ({ signIn, openPrivacyPolicy, setUpThemes }) => (
   <PanelLayout>
     <div className={css(styles.container)}>
       <div className={css(styles.contactAuthorWrapper)}>
@@ -48,7 +48,7 @@ const UserPanel = ({ signIn, openPrivacyPolicy }) => (
         </Link>
       </div>
       <div className={css(styles.themeSettingsWrapper)}>
-        <ThemeSettings />
+        <ThemeSettings setUpThemes={setUpThemes} />
       </div>
       <div className={css(styles.footer)}>
         <div className={css(styles.logInBtnWrapper)}>
@@ -65,6 +65,7 @@ const UserPanel = ({ signIn, openPrivacyPolicy }) => (
 UserPanel.propTypes = {
   signIn: PropTypes.func,
   openPrivacyPolicy: PropTypes.func,
+  setUpThemes: PropTypes.func,
 };
 
 export default UserPanel;

--- a/frontend/src/v1/layouts/Modal/index.jsx
+++ b/frontend/src/v1/layouts/Modal/index.jsx
@@ -10,7 +10,7 @@ const onClick = (event) => {
   event.stopPropagation();
 };
 
-const Modal = ({ maxWidth, maxHeight, controls, children }) => (
+const Modal = ({ maxWidth, maxHeight, controls, children, unscrollableFooter }) => (
   <ModalContext.Consumer>
     {
       ({ closeModal }) => (
@@ -19,24 +19,34 @@ const Modal = ({ maxWidth, maxHeight, controls, children }) => (
             css(
               style.modal,
               maxWidth && maxWidthStyle(maxWidth),
-              maxHeight && maxHeightStyle(maxHeight),
             )
           }
           onClick={onClick}
         >
-          <div className={css(style.controlsContainer)}>
-            <button
-              type="button"
-              className="close"
-              onClick={closeModal}
-              style={{
-                width: '17px',
-                height: '17px',
-              }}
-            />
-            {controls}
+          <div
+            className={
+              css(
+                style.modalInner,
+                unscrollableFooter && style.modalInnerWithFooter,
+                maxHeight && maxHeightStyle(maxHeight),
+              )
+            }
+          >
+            <div className={css(style.controlsContainer)}>
+              <button
+                type="button"
+                className="close"
+                onClick={closeModal}
+                style={{
+                  width: '17px',
+                  height: '17px',
+                }}
+              />
+              {controls}
+            </div>
+            {children}
           </div>
-          {children}
+          {unscrollableFooter}
         </div>
       )
     }
@@ -45,19 +55,23 @@ const Modal = ({ maxWidth, maxHeight, controls, children }) => (
 
 Modal.propTypes = {
   controls: PropTypes.arrayOf(PropTypes.element),
+  unscrollableFooter: PropTypes.node,
 };
 
 const style = StyleSheet.create({
   modal: {
     position: 'relative',
     backgroundColor: 'white',
+    color: '#393C51',
+    minHeight: '64px',
+  },
+  modalInner: {
     paddingTop: '67px',
     paddingLeft: '48px',
     paddingRight: '48px',
     paddingBottom: '56px',
-    color: '#393C51',
-    minHeight: '64px',
   },
+  modalInnerWithFooter: { paddingBottom: '24px' },
   controlsContainer: {
     position: 'absolute',
     content: '',
@@ -77,7 +91,14 @@ const maxWidthStyle = (width) => (
 );
 
 const maxHeightStyle = (height) => (
-  StyleSheet.create({ maxHeight: { height: '100%', maxheight: height } }).maxHeight
+  StyleSheet.create({
+    maxHeight: {
+      height: '100%',
+      maxHeight: height,
+      overflowY: 'auto',
+      overflowX: 'hidden',
+    },
+  }).maxHeight
 );
 
 export default Modal;

--- a/frontend/src/v1/reducers.js
+++ b/frontend/src/v1/reducers.js
@@ -7,6 +7,7 @@ import { default as tagsReducerV1 } from '@/v1/redux/tags/reducer';
 import { default as userSessionReducerV1 } from '@/v1/redux/user_session/reducer';
 import { default as editModeReducerV1 } from '@/v1/redux/editMode/reducer';
 import { default as settingsReducerV1 } from '@/v1/redux/settings/reducer';
+import { default as unselectedThemesIdsReducerV1 } from '@/v1/redux/unselectedThemes/reducer';
 
 export default combineReducers({
   usersStoreV1: usersReducerV1,
@@ -17,4 +18,5 @@ export default combineReducers({
   form: formReducer,
   editMode: editModeReducerV1,
   settingsStoreV1: settingsReducerV1,
+  unselectedThemesIds: unselectedThemesIdsReducerV1,
 });

--- a/frontend/src/v1/redux/unselectedThemes/actions.js
+++ b/frontend/src/v1/redux/unselectedThemes/actions.js
@@ -1,0 +1,8 @@
+import acts from './acts';
+
+export const setUnselectedThemesIds = themesIds => ({
+  type: acts.SET_UNSELECTED_THEMES_IDS,
+  themesIds,
+});
+
+export default setUnselectedThemesIds;

--- a/frontend/src/v1/redux/unselectedThemes/acts.js
+++ b/frontend/src/v1/redux/unselectedThemes/acts.js
@@ -1,0 +1,3 @@
+const acts = { SET_UNSELECTED_THEMES_IDS: 'SET_UNSELECTED_THEMES_IDS_V1' };
+
+export default acts;

--- a/frontend/src/v1/redux/unselectedThemes/reducer.js
+++ b/frontend/src/v1/redux/unselectedThemes/reducer.js
@@ -1,0 +1,12 @@
+import acts from './acts';
+
+const unselectedThemesIdsReducer = (state = [], action) => {
+  switch (action.type) {
+  case acts.SET_UNSELECTED_THEMES_IDS:
+    return action.themesIds;
+  default:
+    return state;
+  }
+};
+
+export default unselectedThemesIdsReducer;

--- a/frontend/src/v1/screens/MainPage.jsx
+++ b/frontend/src/v1/screens/MainPage.jsx
@@ -117,11 +117,22 @@ MainPage.propTypes = {
   loadPosts: PropTypes.func,
 };
 
-const mapStateToProps = state => ({
-  user: currentUser(state),
-  posts: state.postsStoreV1.posts,
-  editMode: state.editMode,
-});
+const mapStateToProps = (state) => {
+  const selectedThemesIds = R.reject(
+    id => R.contains(id, state.unselectedThemesIds),
+    R.map(t => t.id, R.values(state.tagsStoreV1.tags)),
+  );
+  return {
+    user: currentUser(state),
+    posts: R.filter(
+      post => (
+        R.intersection(selectedThemesIds, R.map(tag => tag.id, post.tags)).length > 0
+      ),
+      state.postsStoreV1.posts,
+    ),
+    editMode: state.editMode,
+  };
+};
 
 const mapDispatchToProps = dispatch => ({ loadPosts: () => dispatch(loadPosts()) });
 


### PR DESCRIPTION
Сейчас сделано так, что фильтрация по темам выполняется на стороне фронта. Если ее нужно делать на стороне бекенда, то надо понять как лучше ее сделать.

Видимо страницу со списком карточек постов надо перевести на использование сущности карточки поста, вместо поста, это будет эффективнее, так как иначе получается, что запрашиваются все посты со всех их контентом, а для отображения большая часть этих данных не нужна
НО:

Получится, что надо фильтровать не посты по темам, а карточки по темам, но у карточек есть только главная тема, если нас устраивает такой вариант, т.е. пост будет показываться только, если в выбранных темах есть главная тема поста, то ок, если нет, то надо с карточками возвращать полный список тем поста.
С точки зрения дизайна кажется логичным фильтровать только по главной теме, так как на карточках пишется главная тема и если выбран фильтр "Тема 1", а при этом отображается карточка, на которой написано "Тема 2", это будет казаться не очень логичным

Сейчас выбранные темы сохраняются в глобальное состояние, но само глобальное состояние пока никуда не сохраняется, поэтому при перезагрузке страницы, выбранные темы слетают